### PR TITLE
[backend] Use class serializer interceptor

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,7 +1,7 @@
-import { HttpAdapterHost, NestFactory } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import { ValidationPipe } from '@nestjs/common';
+import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { PrismaClientExceptionFilter } from 'nestjs-prisma';
 
 async function bootstrap() {
@@ -10,6 +10,7 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true })); // enable validation
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector))); // enable serialization
 
   const config = new DocumentBuilder()
     .setTitle('Pong API')

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -4,7 +4,7 @@ import { Exclude } from 'class-transformer';
 
 export class UserEntity implements User {
   constructor(partial: Partial<UserEntity>) {
-	Object.assign(this, partial);
+    Object.assign(this, partial);
   }
 
   @ApiProperty()

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -1,7 +1,12 @@
 import { User } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
+import { Exclude } from 'class-transformer';
 
 export class UserEntity implements User {
+  constructor(partial: Partial<UserEntity>) {
+	Object.assign(this, partial);
+  }
+
   @ApiProperty()
   id: number;
 
@@ -11,5 +16,6 @@ export class UserEntity implements User {
   @ApiProperty({ required: false, nullable: true })
   name: string | null;
 
+  @Exclude()
   password: string;
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  HttpCode,
   ParseIntPipe,
 } from '@nestjs/common';
 import { UserService } from './user.service';
@@ -27,20 +28,21 @@ export class UserController {
 
   @Post()
   @ApiCreatedResponse({ type: UserEntity })
-  async create(@Body() createUserDto: CreateUserDto) {
-    return new UserEntity(await this.userService.create(createUserDto));
+  async create(@Body() createUserDto: CreateUserDto): Promise<UserEntity> {
+    const user = await this.userService.create(createUserDto);
+    return new UserEntity(user);
   }
 
   @Get()
   @ApiOkResponse({ type: [UserEntity] })
-  async findAll() {
+  async findAll(): Promise<UserEntity[]> {
     const users = await this.userService.findAll();
     return users.map((user) => new UserEntity(user));
   }
 
   @Get(':id')
   @ApiOkResponse({ type: UserEntity })
-  async findOne(@Param('id', ParseIntPipe) id: number) {
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<UserEntity> {
     return new UserEntity(await this.userService.findOne(id));
   }
 
@@ -49,13 +51,14 @@ export class UserController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDto,
-  ) {
+  ): Promise<UserEntity> {
     return new UserEntity(await this.userService.update(id, updateUserDto));
   }
 
   @Delete(':id')
+  @HttpCode(204)
   @ApiNoContentResponse()
-  async remove(@Param('id', ParseIntPipe) id: number) {
-    return new UserEntity(await this.userService.remove(id));
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.userService.remove(id);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -28,24 +28,20 @@ export class UserController {
   @Post()
   @ApiCreatedResponse({ type: UserEntity })
   async create(@Body() createUserDto: CreateUserDto) {
-    return new UserEntity(
-		await this.userService.create(createUserDto)
-	);
+    return new UserEntity(await this.userService.create(createUserDto));
   }
 
   @Get()
   @ApiOkResponse({ type: [UserEntity] })
   async findAll() {
     const users = await this.userService.findAll();
-	return users.map(user => new UserEntity(user));
+    return users.map((user) => new UserEntity(user));
   }
 
   @Get(':id')
   @ApiOkResponse({ type: UserEntity })
   async findOne(@Param('id', ParseIntPipe) id: number) {
-    return new UserEntity(
-    	await this.userService.findOne(id)
-	);
+    return new UserEntity(await this.userService.findOne(id));
   }
 
   @Patch(':id')
@@ -54,16 +50,12 @@ export class UserController {
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDto,
   ) {
-    return new UserEntity(
-    	await this.userService.update(id, updateUserDto)
-	);
+    return new UserEntity(await this.userService.update(id, updateUserDto));
   }
 
   @Delete(':id')
   @ApiNoContentResponse()
   async remove(@Param('id', ParseIntPipe) id: number) {
-    return new UserEntity(
-    	await this.userService.remove(id)
-	);
+    return new UserEntity(await this.userService.remove(id));
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -27,34 +27,43 @@ export class UserController {
 
   @Post()
   @ApiCreatedResponse({ type: UserEntity })
-  create(@Body() createUserDto: CreateUserDto) {
-    return this.userService.create(createUserDto);
+  async create(@Body() createUserDto: CreateUserDto) {
+    return new UserEntity(
+		await this.userService.create(createUserDto)
+	);
   }
 
   @Get()
   @ApiOkResponse({ type: [UserEntity] })
-  findAll() {
-    return this.userService.findAll();
+  async findAll() {
+    const users = await this.userService.findAll();
+	return users.map(user => new UserEntity(user));
   }
 
   @Get(':id')
   @ApiOkResponse({ type: UserEntity })
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.userService.findOne(+id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return new UserEntity(
+    	await this.userService.findOne(id)
+	);
   }
 
   @Patch(':id')
   @ApiOkResponse({ type: UserEntity })
-  update(
+  async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateUserDto: UpdateUserDto,
   ) {
-    return this.userService.update(+id, updateUserDto);
+    return new UserEntity(
+    	await this.userService.update(id, updateUserDto)
+	);
   }
 
   @Delete(':id')
   @ApiNoContentResponse()
-  remove(@Param('id', ParseIntPipe) id: number) {
-    return this.userService.remove(+id);
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return new UserEntity(
+    	await this.userService.remove(id)
+	);
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -17,30 +17,23 @@ export class UserService {
   }
 
   findAll(): Promise<User[]> {
-    return this.prisma.user
-      .findMany();
+    return this.prisma.user.findMany();
   }
 
   findOne(id: number): Promise<User> {
-    return this.prisma.user
-      .findUniqueOrThrow({ where: { id: id } });
+    return this.prisma.user.findUniqueOrThrow({ where: { id: id } });
   }
 
-  update(
-    id: number,
-    updateUserDto: UpdateUserDto,
-  ): Promise<User> {
-    return this.prisma.user
-      .update({
-        where: { id: id },
-        data: updateUserDto,
-      });
+  update(id: number, updateUserDto: UpdateUserDto): Promise<User> {
+    return this.prisma.user.update({
+      where: { id: id },
+      data: updateUserDto,
+    });
   }
 
   remove(id: number): Promise<User> {
-    return this.prisma.user
-      .delete({
-        where: { id: id },
-      });
+    return this.prisma.user.delete({
+      where: { id: id },
+    });
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -9,9 +9,13 @@ import { hash } from 'bcrypt';
 export class UserService {
   constructor(private prisma: PrismaService) {}
 
-  async create(createUserDto: CreateUserDto): Promise<User> {
+  hashPassword(password: string): Promise<string> {
     const saltRounds = 10;
-    const hashedPassword = await hash(createUserDto.password, saltRounds);
+    return hash(password, saltRounds);
+  }
+
+  async create(createUserDto: CreateUserDto): Promise<User> {
+    const hashedPassword = await this.hashPassword(createUserDto.password);
     const userData = { ...createUserDto, password: hashedPassword };
     return this.prisma.user.create({ data: userData });
   }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -5,53 +5,42 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { User, Prisma } from '@prisma/client';
 import { hash } from 'bcrypt';
 
-type UserWithoutPassword = Omit<User, 'password'>;
-
-function excludePassword(user: User): Omit<User, 'password'> {
-  const { password, ...userWithoutPassword } = user;
-  return userWithoutPassword;
-}
-
 @Injectable()
 export class UserService {
   constructor(private prisma: PrismaService) {}
 
-  async create(createUserDto: CreateUserDto): Promise<UserWithoutPassword> {
+  async create(createUserDto: CreateUserDto): Promise<User> {
     const saltRounds = 10;
     const hashedPassword = await hash(createUserDto.password, saltRounds);
     const userData = { ...createUserDto, password: hashedPassword };
-    return this.prisma.user.create({ data: userData }).then(excludePassword);
+    return this.prisma.user.create({ data: userData });
   }
 
-  findAll(): Promise<UserWithoutPassword[]> {
+  findAll(): Promise<User[]> {
     return this.prisma.user
-      .findMany()
-      .then((users) => users.map(excludePassword));
+      .findMany();
   }
 
-  findOne(id: number): Promise<UserWithoutPassword> {
+  findOne(id: number): Promise<User> {
     return this.prisma.user
-      .findUniqueOrThrow({ where: { id: id } })
-      .then(excludePassword);
+      .findUniqueOrThrow({ where: { id: id } });
   }
 
   update(
     id: number,
     updateUserDto: UpdateUserDto,
-  ): Promise<UserWithoutPassword> {
+  ): Promise<User> {
     return this.prisma.user
       .update({
         where: { id: id },
         data: updateUserDto,
-      })
-      .then(excludePassword);
+      });
   }
 
-  remove(id: number): Promise<UserWithoutPassword> {
+  remove(id: number): Promise<User> {
     return this.prisma.user
       .delete({
         where: { id: id },
-      })
-      .then(excludePassword);
+      });
   }
 }


### PR DESCRIPTION
UserEntityをResponseタイプに持つhandlerから自動的に`@Exclude`で指定したpasswordカラムが削除されるようにしました。
とはいえ、Prismaで指定されたUserを返り値に指定してしまうことがあったらダメなので、もっとまともなチェックはないのかなーという感じがしました。

cf. Building a REST API with NestJS and Prisma: Handling Relational Data https://www.prisma.io/blog/nestjs-prisma-relational-data-7D056s1kOabc#add-a-user-model-to-the-database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced global interceptors for enhanced data handling.
- **Refactor**
  - Updated `UserEntity` class to include a constructor and exclude password from serialization.
  - Modified `UserController` and `UserService` classes for improved data return types.
- **Bug Fixes**
  - Removed the `excludePassword` function to prevent password exposure in user objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->