### PR TITLE
[backend] Add prisma generate to entrypoint.sh

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 yarn prisma migrate deploy
+yarn prisma generate
 yarn prisma db seed
 exec "$@"


### PR DESCRIPTION
ローカルで`make dev`に失敗したため、原因を探っていたらprisma generateを叩いていないことだった。
（というかどちらかといえばnode_modulesがvolumeとなっていることか。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the backend setup script to automatically generate Prisma client based on the schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->