### PR TITLE
Fix make clean to remove volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ rebuild:
 
 .PHONY: clean
 clean:
-	docker compose down --rmi all --volumes --remove-orphans
+	docker compose down -f compose.yml -f compose.dev.yml --rmi all --volumes --remove-orphans
 
 .PHONY: test
 test: build unit e2e front


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the `clean` process in the Makefile to ensure a more controlled cleanup when using Docker Compose, by specifying which compose files to consider during the cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->