### PR TITLE
Feat/chat/separate messages for each room

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -20,13 +20,35 @@ export class ChatGateway {
   private logger: Logger = new Logger('ChatGateway');
 
   @SubscribeMessage('newMessage')
-  chatMessage(
+  chatMessageToRoom(
     @MessageBody() data: string,
     @ConnectedSocket() client: Socket,
   ): void {
     this.logger.log('message recieved');
     this.logger.log(data);
-    this.server.emit('sendToClient', data, client.id);
+    const rooms = [...client.rooms].slice(0);
+    this.logger.log('rooms', rooms);
+    this.server.to(rooms[1]).emit('sendToClient', data, client.id);
+  }
+
+  @SubscribeMessage('joinRoom')
+  handleJoin(
+    @MessageBody() roomId: string,
+    @ConnectedSocket() client: Socket,
+  ) {
+    this.logger.log(`join room: ${client.id} joined room ${roomId}`);
+    const rooms = [...client.rooms].slice(0);
+    client.join(roomId);
+  }
+
+  @SubscribeMessage('leaveRoom')
+  handleLeave(
+    @MessageBody() roomId: string,
+    @ConnectedSocket() client: Socket,
+  ) {
+    this.logger.log(`leave room: ${client.id} leaved room ${roomId}`);
+    const rooms = [...client.rooms].slice(0);
+    client.leave(roomId);
   }
 
   handleConnection(@ConnectedSocket() client: Socket) {

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -26,7 +26,7 @@ export class ChatGateway {
   ): void {
     this.logger.log('message recieved');
     this.logger.log(data);
-    const rooms = [...client.rooms].slice(0);
+    const rooms = [...client.rooms];
     this.logger.log('rooms', rooms);
     this.server.to(rooms[1]).emit('sendToClient', data, client.id);
   }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -32,12 +32,8 @@ export class ChatGateway {
   }
 
   @SubscribeMessage('joinRoom')
-  handleJoin(
-    @MessageBody() roomId: string,
-    @ConnectedSocket() client: Socket,
-  ) {
+  handleJoin(@MessageBody() roomId: string, @ConnectedSocket() client: Socket) {
     this.logger.log(`join room: ${client.id} joined room ${roomId}`);
-    const rooms = [...client.rooms].slice(0);
     client.join(roomId);
   }
 
@@ -47,7 +43,6 @@ export class ChatGateway {
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.log(`leave room: ${client.id} leaved room ${roomId}`);
-    const rooms = [...client.rooms].slice(0);
     client.leave(roomId);
   }
 

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -1,142 +1,147 @@
-import { getRoom } from "@/app/lib/actions";
-
-export default async function getRoomInfo({
-  params: { id },
-}: {
-  params: { id: number };
-}) {
-  const room = await getRoom(id);
-  return (
-    <div>
-      <h1>
-        <b>Room info</b>
-      </h1>
-      room ID: {room.id} <br />
-      room name: {room.name} <br />
-      {room.users.map((user: Array<any>) => {
-        return Object.entries(user).map(([key, value]) => {
-          return (
-            <div key={key}>
-              {key} : {value}
-            </div>
-          );
-        });
-      })}
-    </div>
-  );
-}
-
-//"use client";
+//import { getRoom } from "@/app/lib/actions";
 //
-//import {
-//  Card,
-//  CardHeader,
-//  CardContent,
-//  CardFooter,
-//  CardDescription,
-//  CardTitle,
-//} from "@/components/ui/card";
-//import { Input } from "@/components/ui/input";
-//import { Button } from "@/components/ui/button";
-//import { ScrollArea } from "@/components/ui/scroll-area";
-//import ChatHome from "@/app/ui/room/chat-room";
-//import { useState, useEffect } from "react";
-//import { socket } from "@/socket";
-//
-//type Chat = {
-//  text: string;
-//};
-//
-//type MessageLog = Array<Chat>;
-//
-//export default function ChatRoomPage({
+//export default async function getRoomInfo({
 //  params: { id },
 //}: {
 //  params: { id: number };
 //}) {
-//
-//  const [message, setMessage] = useState("");
-//  const [messageLog, setMessageLog] = useState<MessageLog>([
-//    {
-//      text: "example message logs",
-//    },
-//    {
-//      text: "Hello world",
-//    },
-//    {
-//      text: "hoge hoge",
-//    },
-//  ]);
-//
-//  useEffect(() => {
-//    const newMessageReceived = (e: any) => {
-//      console.log(`received message: `, e);
-//      setMessageLog((oldMessageLog) => [...oldMessageLog, { text: e }]);
-//      console.log(messageLog);
-//    };
-//    socket.on("sendToClient", newMessageReceived);
-//    return () => {
-//      console.log(`return from useEffect`);
-//      socket.off("sendToClient", newMessageReceived);
-//    };
-//  }, [messageLog]);
-//
-//  useEffect(() => {
-//    socket.connect(); // no-op if the socket is already connected
-//    return () => {
-//      console.log("disconnect");
-//      socket.disconnect();
-//    };
-//  }, []);
-//
-//  const sendMessage = async (e: React.SyntheticEvent) => {
-//    e.preventDefault();
-//    const newMessage = message;
-//    console.log(`sendMessage`, newMessage);
-//    socket.emit("newMessage", newMessage);
-//    setMessage("");
-//  };
-//
+//  const room = await getRoom(id);
 //  return (
-//    <div className="flex items-center justify-center">
-//      <Card className="w-[800px] grid grid-rows-[min-content_1fr_min-content]">
-//        <CardHeader>
-//          <CardTitle>Chat room</CardTitle>
-//          <CardDescription>Experimental chat room</CardDescription>
-//        </CardHeader>
-//        <CardContent>
-//          <ScrollArea className="h-[500px] w-full space-y-1 pr-3">
-//            <div className="flex gap-3 text-slate-600 text-sm">
-//              <ul>
-//                {messageLog.map((message, i) => {
-//                  return (
-//                    <div key={i} className="flex gap-3 text-slate-600 text-sm">
-//                      {" "}
-//                      <li>{message.text}</li>
-//                    </div>
-//                  );
-//                })}
-//              </ul>
+//    <div>
+//      <h1>
+//        <b>Room info</b>
+//      </h1>
+//      room ID: {room.id} <br />
+//      room name: {room.name} <br />
+//      {room.users.map((user: Array<any>) => {
+//        return Object.entries(user).map(([key, value]) => {
+//          return (
+//            <div key={key}>
+//              {key} : {value}
 //            </div>
-//          </ScrollArea>
-//        </CardContent>
-//        <CardFooter>
-//          <form
-//            className="space-x-2 w-full flex gap-2"
-//            id="chat-content"
-//            onSubmit={sendMessage}
-//          >
-//            <Input
-//              placeholder="Message..."
-//              name="message"
-//              value={message}
-//              onChange={(e) => setMessage(e.target.value)}
-//              type="text"
-//            />
-//            <Button type="submit">Send</Button>
-//          </form>
-//        </CardFooter>
-//      </Card>
+//          );
+//        });
+//      })}
 //    </div>
 //  );
 //}
+
+"use client";
+
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardFooter,
+  CardDescription,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import ChatHome from "@/app/ui/room/chat-room";
+import { useState, useEffect } from "react";
+import { socket } from "@/socket";
+
+type Chat = {
+  text: string;
+};
+
+type MessageLog = Array<Chat>;
+
+export default function ChatRoomPage({
+  params: { id },
+}: {
+  params: { id: number };
+}) {
+
+  const [message, setMessage] = useState("");
+  const [messageLog, setMessageLog] = useState<MessageLog>([
+    {
+      text: "example message logs",
+    },
+    {
+      text: "Hello world",
+    },
+    {
+      text: "hoge hoge",
+    },
+  ]);
+
+  useEffect(() => {
+    const newMessageReceived = (e: any) => {
+      console.log(`received message: `, e);
+      setMessageLog((oldMessageLog) => [...oldMessageLog, { text: e }]);
+      console.log(messageLog);
+    };
+    socket.on("sendToClient", newMessageReceived);
+    return () => {
+      console.log(`return from useEffect`);
+      socket.off("sendToClient", newMessageReceived);
+    };
+  }, [messageLog]);
+
+  useEffect(() => {
+    socket.connect(); // no-op if the socket is already connected
+    socket.emit('joinRoom', id);
+    console.log('emit joinRoom');
+
+    return () => {
+      socket.emit('leaveRoom', id);
+      console.log('emit leaveRoom');
+      console.log("disconnect");
+      socket.disconnect();
+    };
+  }, []);
+
+  const sendMessage = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const newMessage = message;
+    console.log(`sendMessage`, newMessage);
+    socket.emit("newMessage", newMessage);
+    setMessage("");
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <Card className="w-[800px] grid grid-rows-[min-content_1fr_min-content]">
+        <CardHeader>
+          <CardTitle>Chat room</CardTitle>
+          <CardDescription>Experimental chat room</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ScrollArea className="h-[500px] w-full space-y-1 pr-3">
+            <div className="flex gap-3 text-slate-600 text-sm">
+              <ul>
+                {messageLog.map((message, i) => {
+                  return (
+                    <div key={i} className="flex gap-3 text-slate-600 text-sm">
+                      {" "}
+                      <li>{message.text}</li>
+                    </div>
+                  );
+                })}
+              </ul>
+            </div>
+          </ScrollArea>
+        </CardContent>
+        <CardFooter>
+          <form
+            className="space-x-2 w-full flex gap-2"
+            id="chat-content"
+            onSubmit={sendMessage}
+          >
+            <Input
+              placeholder="Message..."
+              name="message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              type="text"
+            />
+            <Button type="submit">Send</Button>
+          </form>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -54,7 +54,6 @@ export default function ChatRoomPage({
 }: {
   params: { id: number };
 }) {
-
   const [message, setMessage] = useState("");
   const [messageLog, setMessageLog] = useState<MessageLog>([
     {
@@ -83,12 +82,12 @@ export default function ChatRoomPage({
 
   useEffect(() => {
     socket.connect(); // no-op if the socket is already connected
-    socket.emit('joinRoom', id);
-    console.log('emit joinRoom');
+    socket.emit("joinRoom", id);
+    console.log("emit joinRoom");
 
     return () => {
-      socket.emit('leaveRoom', id);
-      console.log('emit leaveRoom');
+      socket.emit("leaveRoom", id);
+      console.log("emit leaveRoom");
       console.log("disconnect");
       socket.disconnect();
     };

--- a/frontend/socket.ts
+++ b/frontend/socket.ts
@@ -1,2 +1,2 @@
 import { io } from "socket.io-client";
-export const socket = io("http://" + `${process.env.NEXT_PUBLIC_WEB_URL}`);
+export const socket = io("http://" + `${process.env.NEXT_PUBLIC_WEB_URL}`, { autoConnect: false });

--- a/frontend/socket.ts
+++ b/frontend/socket.ts
@@ -1,2 +1,4 @@
 import { io } from "socket.io-client";
-export const socket = io("http://" + `${process.env.NEXT_PUBLIC_WEB_URL}`, { autoConnect: false });
+export const socket = io("http://" + `${process.env.NEXT_PUBLIC_WEB_URL}`, {
+  autoConnect: false,
+});


### PR DESCRIPTION
[backend]
socket.ioのroomへのjoinとleaveを扱う関数を追加しました
clientから受け取ったメッセージをそのclient socketが参加しているroomにだけ送り返すように変更しました

[frontend]
room/{id}をレンダリングする際にjoinRoom eventをemitするように変更しました
room/{id}から離れる際にleaveRoom eventをemitするように変更しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced chat room functionality with the ability to join and leave chat rooms.
  - Real-time messaging within chat rooms is now supported.
  - Chat room details are now fetched asynchronously and displayed on the room page.

- **Enhancements**
  - Improved user control over WebSocket connections with manual connection initiation.

- **Refactor**
  - Updated chat message handling to support room-specific communication.
  - Streamlined chat room information retrieval and display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->