### PR TITLE
Get information from canvas

### DIFF
--- a/frontend/app/pong/[id]/PongBoard.tsx
+++ b/frontend/app/pong/[id]/PongBoard.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { memo, useEffect, useRef, useState } from "react";
+import { io, Socket } from "socket.io-client";
+import { PongGame } from "./PongGame";
+import { TARGET_FRAME_MS } from "./const";
+import { Button } from "@/components/ui/button";
+
+type setFunction = (value: number) => void;
+
+interface PongBoardProps {
+  id: string;
+  setFps: setFunction;
+  setSpeed: setFunction;
+  setPlayer1Position: setFunction;
+  setPlayer2Position: setFunction;
+}
+function PongBoard({
+  id: id,
+  setFps: setFps,
+  setSpeed: setSpeed,
+  setPlayer1Position: setPlayer1Position,
+  setPlayer2Position: setPlayer2Position,
+}: PongBoardProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [socket, setSocket] = useState<Socket>(undefined!);
+  // todo: useRef vs useState
+  const game = useRef<PongGame>(
+    new PongGame(setFps, setSpeed, setPlayer1Position, setPlayer2Position),
+  );
+  useEffect(() => {
+    // > If the contextType doesn't match a possible drawing context, or differs from the first contextType requested, null is returned."
+    // from https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) {
+      console.warn("2d canvas is not supported or there is a bug");
+      return;
+    }
+    const socket = io(process.env.NEXT_PUBLIC_WEB_URL as string);
+    setSocket(socket);
+
+    game.current.setup_canvas(ctx, socket);
+    game.current.draw_canvas();
+    const intervalId = setInterval(game.current.update, TARGET_FRAME_MS);
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      game.current.keypress[event.key] = false;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      game.current.keypress[event.key] = true;
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    document.addEventListener("keyup", handleKeyUp);
+
+    socket.on("connect", () => {
+      console.log(`Connected: ${socket.id}`);
+
+      socket.emit("join", id);
+    });
+
+    socket.on("start", (data) => {
+      console.log(`Start: ${JSON.stringify(data)}`);
+      game.current.start(data);
+    });
+
+    socket.on("right", () => {
+      game.current.player2.clear(game.current.ctx);
+      game.current.player2.move_left();
+      game.current.player2.draw(game.current.ctx);
+    });
+
+    socket.on("left", () => {
+      game.current.player2.clear(game.current.ctx);
+      game.current.player2.move_right();
+      game.current.player2.draw(game.current.ctx);
+    });
+
+    socket.on("bounce", () => {
+      game.current.ball.bounce_off_paddle(game.current.player2);
+    });
+
+    socket.on("collide", () => {
+      game.current.ball.reset();
+      game.current.score.player1++;
+    });
+
+    return () => {
+      socket.disconnect();
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+      clearInterval(intervalId);
+    };
+  }, [id]);
+
+  const start = () => {
+    game.current.start();
+    socket.emit("start", {
+      vx: -game.current.ball.vx,
+      vy: -game.current.ball.vy,
+    });
+  };
+
+  return (
+    <>
+      <div>
+        <Button onClick={start}>Start</Button>
+        <Button onClick={game.current.switch_battle_mode}>Battle</Button>
+        <Button onClick={game.current.switch_practice_mode}>Practice</Button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width="256"
+        height="512"
+        className="border w-[256px] h-[512px]"
+      ></canvas>
+    </>
+  );
+}
+
+const memoizedPongBoard = memo(PongBoard);
+export default memoizedPongBoard;
+// export default PongBoard;

--- a/frontend/app/pong/[id]/PongGame.ts
+++ b/frontend/app/pong/[id]/PongGame.ts
@@ -13,6 +13,8 @@ import {
   TARGET_FRAME_MS,
 } from "./const";
 
+type setFunction = (value: number) => void;
+
 export class PongGame {
   ctx!: CanvasRenderingContext2D;
   player1: Paddle;
@@ -25,9 +27,20 @@ export class PongGame {
   frame_count: number;
   is_playing: boolean;
   keypress: { [key: string]: boolean };
+
+  setFps: setFunction;
+  setSpeed: setFunction;
+  setPlayer1Position: setFunction;
+  setPlayer2Position: setFunction;
+
   socket!: Socket;
 
-  constructor() {
+  constructor(
+    setFps: setFunction,
+    setSpeed: setFunction,
+    setPlayer1Position: setFunction,
+    setPlayer2Position: setFunction,
+  ) {
     this.player1 = new Paddle(
       CANVAS_WIDTH / 2 - PADDLE_WIDTH / 2,
       CANVAS_HEIGHT - PADDLE_HEIGHT,
@@ -63,6 +76,10 @@ export class PongGame {
     this.frame_count = 0;
     this.is_playing = false;
     this.keypress = {};
+    this.setFps = setFps;
+    this.setSpeed = setSpeed;
+    this.setPlayer1Position = setPlayer1Position;
+    this.setPlayer2Position = setPlayer2Position;
   }
 
   // call only after rendering finishes
@@ -85,19 +102,19 @@ export class PongGame {
       const fps = Math.round(
         this.frame_count / (elapsed_since_last_update / 1000),
       );
-      // this.setFps(fps);
+      this.setFps(fps);
       this.frame_count = 0;
       this.fps_updated_at = this.updated_at;
     }
   };
 
   update_speed(speed: number) {
-    // this.setSpeed(speed);
+    this.setSpeed(speed);
   }
 
   update_players() {
-    // this.setPlayer1Position(this.player1.x);
-    // this.setPlayer2Position(this.player2.x);
+    this.setPlayer1Position(this.player1.x);
+    this.setPlayer2Position(this.player2.x);
   }
 
   draw_canvas = () => {

--- a/frontend/app/pong/[id]/PongInformationBoard.tsx
+++ b/frontend/app/pong/[id]/PongInformationBoard.tsx
@@ -14,7 +14,7 @@ export default function PongInformationBoard({
   player2Position,
 }: PongInformationBoardProps) {
   return (
-    <>
+    <div className="flex flex-col">
       <div id="fps">FPS: {fps}</div>
       <div id="speed">Speed: {speed}</div>
       <div>
@@ -23,6 +23,6 @@ export default function PongInformationBoard({
       <div>
         player2: <span id="player2">{player2Position}</span>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/app/pong/[id]/page.tsx
+++ b/frontend/app/pong/[id]/page.tsx
@@ -1,104 +1,40 @@
 "use client";
-import { Button } from "@/components/ui/button";
-import { io, Socket } from "socket.io-client";
-import { useEffect, useRef, useState } from "react";
-import { PongGame } from "./PongGame";
-import { TARGET_FRAME_MS } from "./const";
+import { useCallback, useEffect, useRef, useState } from "react";
+import PongInformationBoard from "./PongInformationBoard";
+import PongBoard from "./PongBoard";
 
 export default function Page({ params: { id } }: { params: { id: string } }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [socket, setSocket] = useState<Socket>(undefined!);
-  // todo: useRef vs useState
-  const game = useRef<PongGame>(new PongGame());
+  const [fps, setFps] = useState<number>(0);
+  const [speed, setSpeed] = useState<number>(0);
+  const [player1Position, setPlayer1Position] = useState<number>(0);
+  const [player2Position, setPlayer2Position] = useState<number>(0);
 
-  useEffect(() => {
-    // > If the contextType doesn't match a possible drawing context, or differs from the first contextType requested, null is returned."
-    // from https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
-    const ctx = canvasRef.current?.getContext("2d");
-    if (!ctx) {
-      console.warn("2d canvas is not supported or there is a bug");
-      return;
-    }
-    const socket = io(process.env.NEXT_PUBLIC_WEB_URL as string);
-    setSocket(socket);
-
-    game.current.setup_canvas(ctx, socket);
-    game.current.draw_canvas();
-    const intervalId = setInterval(game.current.update, TARGET_FRAME_MS);
-
-    const handleKeyUp = (event: KeyboardEvent) => {
-      game.current.keypress[event.key] = false;
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      game.current.keypress[event.key] = true;
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-
-    document.addEventListener("keyup", handleKeyUp);
-
-    socket.on("connect", () => {
-      console.log(`Connected: ${socket.id}`);
-
-      socket.emit("join", id);
-    });
-
-    socket.on("start", (data) => {
-      console.log(`Start: ${JSON.stringify(data)}`);
-      game.current.start(data);
-    });
-
-    socket.on("right", () => {
-      game.current.player2.clear(game.current.ctx);
-      game.current.player2.move_left();
-      game.current.player2.draw(game.current.ctx);
-    });
-
-    socket.on("left", () => {
-      game.current.player2.clear(game.current.ctx);
-      game.current.player2.move_right();
-      game.current.player2.draw(game.current.ctx);
-    });
-
-    socket.on("bounce", () => {
-      game.current.ball.bounce_off_paddle(game.current.player2);
-    });
-
-    socket.on("collide", () => {
-      game.current.ball.reset();
-      game.current.score.player1++;
-    });
-
-    return () => {
-      socket.disconnect();
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("keyup", handleKeyUp);
-      clearInterval(intervalId);
-    };
-  }, [id]);
-
-  const start = () => {
-    game.current.start();
-    socket.emit("start", {
-      vx: -game.current.ball.vx,
-      vy: -game.current.ball.vy,
-    });
-  };
+  const memoizedSetFps = useCallback((fps: number) => setFps(fps), []);
+  const memoizedSetSpeed = useCallback((speed: number) => setSpeed(speed), []);
+  const memoizedSetPlayer1Position = useCallback(
+    (player1Position: number) => setPlayer1Position(player1Position),
+    [],
+  );
+  const memoizedSetPlayer2Position = useCallback(
+    (player2Position: number) => setPlayer2Position(player2Position),
+    [],
+  );
 
   return (
     <>
-      {/* <PongInformationBoard {} /> */}
-      <div>
-        <Button onClick={start}>Start</Button>
-        <Button onClick={game.current.switch_battle_mode}>Battle</Button>
-        <Button onClick={game.current.switch_practice_mode}>Practice</Button>
-      </div>
-      <canvas
-        ref={canvasRef}
-        width="256"
-        height="512"
-        className="border w-[256px] h-[512px]"
-      ></canvas>
+      <PongInformationBoard
+        fps={fps}
+        speed={speed}
+        player1Position={player1Position}
+        player2Position={player2Position}
+      />
+      <PongBoard
+        id={id}
+        setFps={memoizedSetFps}
+        setSpeed={memoizedSetSpeed}
+        setPlayer1Position={memoizedSetPlayer1Position}
+        setPlayer2Position={memoizedSetPlayer2Position}
+      />
     </>
   );
 }


### PR DESCRIPTION
canvasからの情報を表示する方法を悩んでいたのだが、Reactドキュメント見てたら分かったので実装。

コード見てもらったら分かると思うが、useStateのsetterをuseCallbackに入れてキャッシュさせて、memoを読んだcanvasを含んだコンポーネントに入れると、親コンポーネントが再レンダリングしても、小コンポーネントの方はpropsが変わってないと判断されてないので再レンダリングが走らない。

（うーん。よくよく考えると、再レンダリングにかかる時間が1msくらいで、fpsは最大でも16msごとにしか変わらないので、別にやる必要なかったのではとも思った🤦）

[memo – React](https://react.dev/reference/react/memo)
[useCallback – React](https://react.dev/reference/react/useCallback)

memoしないとき
![Screenshot 2023-11-24 at 0 01 50](https://github.com/usatie/pong/assets/69781798/a970fe03-6d52-4e96-b024-70499043908a)

memoしたとき
![Screenshot 2023-11-24 at 0 02 37](https://github.com/usatie/pong/assets/69781798/bdd9a711-0a35-4a2c-9571-cec05a9cad60)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `PongBoard` component for real-time Pong game interaction with WebSocket support.
  - Added new game modes: battle mode and practice mode accessible via the game interface.
  - Launched a `PongInformationBoard` component to display game stats such as FPS and speed.

- **Enhancements**
  - Improved game state management with new state variables for FPS, speed, and player positions.
  - Enhanced user experience by providing a more structured and informative game interface.

- **Refactor**
  - Replaced previous game logic with modular components for better maintainability and readability.
  - Streamlined state management and event handling within the game components.

- **Style**
  - Updated the visual structure of the game's information display for a cleaner layout and better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->