### PR TITLE
Use namespace for pong websocket

### DIFF
--- a/backend/src/events/events.gateway.ts
+++ b/backend/src/events/events.gateway.ts
@@ -6,16 +6,17 @@ import {
   ConnectedSocket,
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
-import { Server, Socket } from 'socket.io';
+import { Namespace, Socket } from 'socket.io';
 
 @WebSocketGateway({
   cors: {
     origin: '*',
   },
+  namespace: '/pong',
 })
 export class EventsGateway implements OnGatewayDisconnect {
   @WebSocketServer()
-  server: Server;
+  server: Namespace;
   started: boolean = false;
 
   handleDisconnect(client: Socket) {
@@ -30,7 +31,7 @@ export class EventsGateway implements OnGatewayDisconnect {
     @ConnectedSocket() client: Socket,
   ): Promise<string> {
     console.log(`join: ${JSON.stringify(data)} ${client.id}`);
-    const connectClients = this.server.of('/').adapter.rooms.get(data);
+    const connectClients = this.server.adapter.rooms.get(data);
     if (connectClients && connectClients.size > 1) {
       console.log('too many clients');
       return 'too many clients';
@@ -38,9 +39,7 @@ export class EventsGateway implements OnGatewayDisconnect {
     client.join(data);
     console.log(client.rooms);
     console.log(
-      `joined: ${client.id} ${
-        this.server.of('/').adapter.rooms.get(data).size
-      }`,
+      `joined: ${client.id} ${this.server.adapter.rooms.get(data).size}`,
     );
     return data;
   }

--- a/frontend/app/pong/[id]/PongBoard.tsx
+++ b/frontend/app/pong/[id]/PongBoard.tsx
@@ -36,7 +36,7 @@ function PongBoard({
       console.warn("2d canvas is not supported or there is a bug");
       return;
     }
-    const socket = io(process.env.NEXT_PUBLIC_WEB_URL as string);
+    const socket = io(process.env.NEXT_PUBLIC_WEB_URL! + "/pong");
     setSocket(socket);
 
     game.current.setup_canvas(ctx, socket);


### PR DESCRIPTION

- 現在の挙動（socket.ioというよりはnest？）
    - 複数のgatewayが定義されてて、同じ `eventType` が登録されてたらどっちも呼ばれる

[Namespaces | Socket.IO](https://socket.io/docs/v4/namespaces/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated namespace for improved socket communication in the "pong" feature.

- **Refactor**
  - Updated socket connection handling to align with the new namespace structure.

- **Style**
  - Adjusted logging statements for clarity in socket-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->