### PR TITLE
Frontend/chat/not found

### DIFF
--- a/frontend/app/direct-message/[directMessageId]/not-found.tsx
+++ b/frontend/app/direct-message/[directMessageId]/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex h-full flex-col items-center justify-center gap-2">
+      <h2 className="text-xl font-semibold">404 Not Found</h2>
+      <p>Could not find the requested User.</p>
+      <Link
+        href="/direct-message"
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-red-400"
+      >
+        Go Back
+      </Link>
+    </main>
+  );
+}

--- a/frontend/app/direct-message/[directMessageId]/page.tsx
+++ b/frontend/app/direct-message/[directMessageId]/page.tsx
@@ -2,6 +2,7 @@ import ChatRoomCard from "@/app/ui/direct-message/chat-room";
 import { getUserId } from "@/app/lib/session";
 import { getUsers, getUser } from "@/app/lib/actions";
 import type { User } from "@/app/ui/user/card";
+import { notFound } from "next/navigation";
 
 export default async function Page({
   params: { directMessageId },
@@ -22,9 +23,8 @@ export default async function Page({
   const otherUser = otherUsers.find(
     (user) => user.id === parseInt(directMessageId),
   );
-  if (!otherUser) {
-    console.error("error");
-    return null;
+  if (!otherUser || otherUser.id === parseInt(currentUserId)) {
+    notFound();
   }
   return <ChatRoomCard yourself={currentUser} other={otherUser} />;
 }

--- a/frontend/app/room/[id]/not-found.tsx
+++ b/frontend/app/room/[id]/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex h-full flex-col items-center justify-center gap-2">
+      <h2 className="text-xl font-semibold">404 Not Found</h2>
+      <p>Could not find the requested room.</p>
+      <Link
+        href="/room"
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-red-400"
+      >
+        Go Back
+      </Link>
+    </main>
+  );
+}

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -45,5 +45,5 @@ export default async function Page({
     return null;
   }
   const currentUser = await getUser(parseInt(currentUserId));
-  return <ChatRoomCard id={id} user={currentUser} />;
+  return <ChatRoomCard id={id} user={currentUser} roomName={roomInfo.name} />;
 }

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -1,4 +1,3 @@
-//import { getRoom } from "@/app/lib/actions";
 //
 //export default async function getRoomInfo({
 //  params: { id },
@@ -28,13 +27,18 @@
 
 import ChatRoomCard from "@/app/ui/room/chat-room";
 import { getUserId } from "@/app/lib/session";
-import { getUser } from "@/app/lib/actions";
+import { getRoom, getUser } from "@/app/lib/actions";
+import { notFound } from "next/navigation";
 
 export default async function Page({
   params: { id },
 }: {
   params: { id: number };
 }) {
+  const roomInfo = await getRoom(id);
+  if (!roomInfo) {
+    notFound();
+  }
   const currentUserId = await getUserId();
   if (!currentUserId) {
     console.error("error");

--- a/frontend/app/ui/direct-message/chat-room.tsx
+++ b/frontend/app/ui/direct-message/chat-room.tsx
@@ -89,7 +89,7 @@ export default function ChatRoom({
     <div className="flex items-center justify-center">
       <Card className="w-[600px] grid grid-rows-[min-content_1fr_min-content]">
         <CardHeader>
-          <CardTitle>Chat room</CardTitle>
+          <CardTitle>{other.name}</CardTitle>
           <CardDescription>Experimental chat room</CardDescription>
         </CardHeader>
         <CardContent>

--- a/frontend/app/ui/room/chat-room.tsx
+++ b/frontend/app/ui/room/chat-room.tsx
@@ -23,7 +23,15 @@ type Chat = {
 
 type MessageLog = Array<Chat>;
 
-export default function ChatRoom({ id, user }: { id: number; user: User }) {
+export default function ChatRoom({
+  id,
+  user,
+  roomName,
+}: {
+  id: number;
+  user: User;
+  roomName: string;
+}) {
   const [message, setMessage] = useState("");
   const [messageLog, setMessageLog] = useState<MessageLog>([]);
 
@@ -67,7 +75,7 @@ export default function ChatRoom({ id, user }: { id: number; user: User }) {
     <div className="flex items-center justify-center">
       <Card className="w-[600px] grid grid-rows-[min-content_1fr_min-content]">
         <CardHeader>
-          <CardTitle>Chat room</CardTitle>
+          <CardTitle>{roomName} room</CardTitle>
           <CardDescription>Experimental chat room</CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
[frontend]
 - 存在しないroomやuser(DM)にアクセスした時404のエラーページを表示するように変更しました。
 - 現在いるchat roomの名前(DMなら相手のユーザー名)を表示して今どのchat内に居るか分かるようにしました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `NotFound` component for Direct Messages and Rooms, providing a user-friendly 404 Not Found message with navigation back to the respective pages.

- **Enhancements**
  - Updated chat room titles to dynamically display the name of the chat participant or room name for a more personalized experience.

- **Bug Fixes**
  - Implemented checks to redirect users to a 404 page when attempting to access non-existent or unauthorized Direct Messages or Rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->