### PR TITLE
Feat/chat/websocket with namespace and specific path

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -24,6 +24,8 @@ type PrivateReceived = {
   cors: {
     origin: '*',
   },
+  path: '/socket.io/chat/',
+  namespace: 'chat',
 })
 export class ChatGateway {
   @WebSocketServer()

--- a/frontend/app/ui/direct-message/chat-room.tsx
+++ b/frontend/app/ui/direct-message/chat-room.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useState, useEffect } from "react";
-import { socket } from "@/socket";
+import { chatSocket as socket } from "@/socket";
 import type { User } from "@/app/ui/user/card";
 
 type DM = {

--- a/frontend/app/ui/room/chat-room.tsx
+++ b/frontend/app/ui/room/chat-room.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useState, useEffect } from "react";
-import { socket } from "@/socket";
+import { chatSocket as socket } from "@/socket";
 import type { User } from "@/app/ui/user/card";
 
 type Chat = {

--- a/frontend/socket.ts
+++ b/frontend/socket.ts
@@ -1,5 +1,6 @@
 import { io } from "socket.io-client";
-export const socket = io(`${process.env.NEXT_PUBLIC_WEB_URL}`, {
+export const socket = io(process.env.NEXT_PUBLIC_WEB_URL! + "/chat", {
+  path: "/socket.io/chat/",
   autoConnect: false,
 });
 

--- a/frontend/socket.ts
+++ b/frontend/socket.ts
@@ -1,5 +1,5 @@
 import { io } from "socket.io-client";
-export const socket = io(process.env.NEXT_PUBLIC_WEB_URL! + "/chat", {
+export const chatSocket = io(process.env.NEXT_PUBLIC_WEB_URL! + "/chat", {
   path: "/socket.io/chat/",
   autoConnect: false,
 });

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -43,5 +43,16 @@ http {
 			proxy_set_header X-Forwarded-Host $host;
 			proxy_set_header X-Forwarded-Port $server_port;
 		}
+		location /socket.io/chat {
+			proxy_pass http://backend:3000/socket.io/chat;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_set_header X-Forwarded-Host $host;
+			proxy_set_header X-Forwarded-Port $server_port;
+		}
 	}
 }


### PR DESCRIPTION
[frontend/backend]
 - chatのwebsocketにnamespaceを適用しました。
 - chatのgatewayとclient socketにpathを設定しました。

[nginx]
 - nginx.confにchat websocket用のlocationを追加しました。
 
 pathも設定してみましたがnamespaceだけで良さそう？
 developer toolで違いがわかりやすくなる位のメリットしか分かってないです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chat functionality with dedicated WebSocket namespaces and paths for improved organization and connection handling.
  - Updated frontend chat components to utilize the new dedicated chat socket connections.

- **Refactor**
  - Streamlined WebSocket connection initialization with explicit paths for chat and pong features.

- **Configuration**
  - Configured Nginx to properly route chat WebSocket connections to the backend service.

- **Style**
  - Adjusted import statements in chat-related UI components to align with the updated socket module exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->