### PR TITLE
[backend] review fix

### DIFF
--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -81,7 +81,7 @@ export class RoomService {
 
   removeRoom(id: number, user: User): Promise<RoomEntity> {
     return this.findUserOnRoom(id, user, user.id)
-      .catch((e) => {
+      .catch(() => {
         throw new HttpException('Forbidden', 403);
       })
       .then((userOnRoomEntity) => {

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -81,18 +81,20 @@ export class RoomService {
 
   removeRoom(id: number, user: User): Promise<RoomEntity> {
     return this.findUserOnRoom(id, user, user.id)
-	.catch(e => {throw new HttpException('Forbidden', 403);})
-	.then((userOnRoomEntity) => {
-      if (userOnRoomEntity.role !== Role.OWNER) {
+      .catch((e) => {
         throw new HttpException('Forbidden', 403);
-      } else {
-        return this.removeAllUserOnRoom(id).then(() =>
-          this.prisma.room.delete({
-            where: { id },
-          }),
-        );
-      }
-    });
+      })
+      .then((userOnRoomEntity) => {
+        if (userOnRoomEntity.role !== Role.OWNER) {
+          throw new HttpException('Forbidden', 403);
+        } else {
+          return this.removeAllUserOnRoom(id).then(() =>
+            this.prisma.room.delete({
+              where: { id },
+            }),
+          );
+        }
+      });
   }
 
   // UserOnRoom CRUD

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -296,7 +296,7 @@ describe('AppController (e2e)', () => {
         });
 
     const payloadFromJWT = ({ accessToken }: { accessToken: string }) =>
-      atob(accessToken.split('.')[1]);
+      Buffer.from(accessToken.split('.')[1], 'base64').toString('utf-8');
 
     const getUserWithToken = (user: UserEntity): Promise<UserWithToken> => {
       return request(app.getHttpServer())
@@ -364,7 +364,6 @@ describe('AppController (e2e)', () => {
           const expectedProps: UserEntityKeysWithoutPassword[] = Object.keys(
             new UserEntity({ id: 0, name: '', email: '' }),
           ) as UserEntityKeysWithoutPassword[];
-          console.log(expectedProps);
           const isUserEntity = expectedProps.every((prop) => prop in res.body);
           return isUserEntity ? res.body : Promise.reject(res.body);
         });
@@ -440,6 +439,7 @@ describe('AppController (e2e)', () => {
         }
         //return Promise.all(members.map((user) => testGet(user, 200, room)));
       });
+
       it('from notMember: should return 403 Forbidden', async () => {
         const room = await getRoom(createRoomDto.name);
         const notMember = await loginUser(
@@ -447,6 +447,7 @@ describe('AppController (e2e)', () => {
         );
         await testGet(notMember, 403, room);
       });
+
       it('from unAuthorized User: should return 401 Unauthorized', async () => {
         const room = await getRoom(createRoomDto.name);
 
@@ -520,6 +521,7 @@ describe('AppController (e2e)', () => {
           testPatch(owner, 200, room, { name: createRoomDto.name }),
         );
       });
+
       it('from Member and Admin : should return 403', async () => {
         const users = await Promise.all(userDtos.map((u) => loginUser(u)));
         const room = await getRoom(createRoomDto.name);
@@ -531,6 +533,7 @@ describe('AppController (e2e)', () => {
           members.map((user) => testPatch(user, 403, room, { name: newName })),
         );
       });
+
       it('from notMember : should return 403 Forbidden', async () => {
         const users = await Promise.all(userDtos.map((u) => loginUser(u)));
         const room = await getRoom(createRoomDto.name);
@@ -538,6 +541,7 @@ describe('AppController (e2e)', () => {
 
         return testPatch(notMembers, 403, room, { name: newName });
       });
+
       it('from unAuthorized User: should return 401 Unauthorized', async () => {
         const room = await getRoom(createRoomDto.name);
 
@@ -578,31 +582,6 @@ describe('AppController (e2e)', () => {
 
         return testDelete({ accessToken: '' }, 401, room);
       });
-    });
-
-    describe('PATCH /room/:id/:userId', () => {
-      // const getUserIdFromJWT = ({ accessToken }: { accessToken: string }) =>
-      //   JSON.parse(payloadFromJWT({ accessToken })).userId;
-      // const updateUserRole = (
-      //   changer: UserWithToken,
-      //   changed: UserWithToken,
-      //   { role }: { role: Role },
-      //   room: RoomEntity,
-      // ): Promise<Member> =>
-      //   request(app.getHttpServer())
-      //     .patch(`/room/${room.id}/${getUserIdFromJWT(changed)}`)
-      //     .set('Authorization', `Bearer ${changer.accessToken}`)
-      //     .send({ role })
-      //     .then((res) => ({ ...changed, ...res.body }));
-      // const getOneUserOnRoom = (
-      //   room: RoomEntity,
-      //   user: UserWithToken,
-      // ): Promise<UserOnRoomEntity> =>
-      //   request(app.getHttpServer())
-      //     .get(`/room/${room.id}/${JSON.parse(payloadFromJWT(user)).userId}`)
-      //     .set('Authorization', `Bearer ${user.accessToken}`)
-      //     .send()
-      //     .then((res) => res.body);
     });
   });
 });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -348,6 +348,25 @@ describe('AppController (e2e)', () => {
       request(app.getHttpServer())
         .post('/user')
         .send(dto)
+        .then((res) => {
+          // UserEntity の型から特定のキー（この場合は 'password'）を除外するユーティリティ型
+          type OmitKey<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+          // 'password' 以外の UserEntity のキーを取得する
+          type UserEntityKeysWithoutPassword = keyof OmitKey<
+            UserEntity,
+            'password'
+          >;
+
+          // 'password' 以外のキーを配列として取得する
+          const expectedProps: UserEntityKeysWithoutPassword[] = Object.keys(
+            new UserEntity({ id: 0, name: '', email: '' }),
+          ) as UserEntityKeysWithoutPassword[];
+          console.log(expectedProps);
+          const isUserEntity = expectedProps.every((prop) => prop in res.body);
+          return isUserEntity ? res.body : Promise.reject(res.body);
+        });
+    const getUsers = () => {
         .then((res) => res.body);
 
     beforeAll(async () => {

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -11,6 +11,8 @@ import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { UserEntity } from 'src/user/entities/user.entity';
 import { RoomEntity } from 'src/room/entities/room.entity';
 import { UpdateRoomDto } from 'src/room/dto/update-room.dto';
+import { UserOnRoomEntity } from 'src/room/entities/UserOnRoom.entity';
+import { AuthEntity } from 'src/auth/entity/auth.entity';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -378,17 +378,22 @@ describe('AppController (e2e)', () => {
       let room;
       for (const dto of userDtos) {
         const user = await createUser(dto);
-        const userWithToken = await getUserWithToken({ ...user, password: dto.password });
+        const userWithToken = await getUserWithToken({
+          ...user,
+          password: dto.password,
+        });
         if (user.name === 'OWNER') {
           room = await createRoom(userWithToken, createRoomDto);
-        } else if (user.name === 'MEMBER' || user.name === "ADMINISTRATOR") {
+        } else if (user.name === 'MEMBER' || user.name === 'ADMINISTRATOR') {
           await enterRoom(userWithToken, room);
         }
       }
     });
 
     afterAll(async () => {
-      const ownerUser = await loginUser(userDtos.find((c) => c.name === 'OWNER'));
+      const ownerUser = await loginUser(
+        userDtos.find((c) => c.name === 'OWNER'),
+      );
       const rooms = await getRooms();
       for (const room of rooms) {
         await deleteRoom(room, ownerUser);
@@ -442,7 +447,9 @@ describe('AppController (e2e)', () => {
       });
       it('from notMember: should return 403 Forbidden', async () => {
         const room = await getRoom(createRoomDto.name);
-        const notMember = await loginUser(userDtos.find((c) => c.name === 'NotMEMBER'));
+        const notMember = await loginUser(
+          userDtos.find((c) => c.name === 'NotMEMBER'),
+        );
         await testGet(notMember, 403, room);
       });
       it('from unAuthorized User: should return 401 Unauthorized', async () => {

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -367,7 +367,10 @@ describe('AppController (e2e)', () => {
           return isUserEntity ? res.body : Promise.reject(res.body);
         });
     const getUsers = () => {
+      return request(app.getHttpServer())
+        .get('/user')
         .then((res) => res.body);
+    };
 
     beforeAll(async () => {
       const createdUsers = await Promise.all(

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -284,7 +284,7 @@ describe('AppController (e2e)', () => {
       atob(accessToken.split('.')[1]);
 
     const getUserIdFromJWT = ({ accessToken }: { accessToken: string }) =>
-      JSON.parse(payloadFromJWT({accessToken})).userId;
+      JSON.parse(payloadFromJWT({ accessToken })).userId;
 
     const updateUserRole = (
       changer: UserWithToken,
@@ -382,9 +382,9 @@ describe('AppController (e2e)', () => {
           .map((roomMember) => enterRoom(roomMember, room)),
       );
 
-		const admin = await updateUserRole(
+      const admin = await updateUserRole(
         usersWithToken.find((u) => u.name === 'OWNER'),
-		usersWithToken.find(u => u.name === 'ADMINISTRATOR'),
+        usersWithToken.find((u) => u.name === 'ADMINISTRATOR'),
         { role: Role.ADMINISTRATOR },
         room,
       );
@@ -396,164 +396,178 @@ describe('AppController (e2e)', () => {
           getRooms().then((rooms) => rooms.map((r) => deleteRoom(r, u))),
         )
         .then(() => {
-          userDtos.map((u) =>
-            loginUser(u).then((uToken) => deleteUser(uToken)),
+          Promise.all(
+            userDtos.map((u) =>
+              loginUser(u).then((uToken) => deleteUser(uToken)),
+            ),
           );
         });
     });
 
-    // describe('GET', () => {
-    //   it('from roomMember: should return the room 200 OK', () => {
-    //     return Promise.all(
-    //       users
-    //         .filter((user) => user.role !== undefined)
-    //         .map((user) => {
-    //           return request(app.getHttpServer())
-    //             .get(`/room/${testRoom.roomId}`)
-    //             .set('Authorization', `Bearer ${user.accessToken}`)
-    //             .expect(200)
-    //             .then((res) => {
-    //               expect(res.body).toHaveProperty('id');
-    //               expect(res.body).toHaveProperty('name');
-    //               expect(res.body).toHaveProperty('users');
-    //               expect(res.body.users).toBeInstanceOf(Array);
-    //               expect(res.body.users.length).toBeGreaterThan(0);
-    //               res.body.users.forEach((user) => {
-    //                 expect(user).toHaveProperty('id');
-    //                 expect(user).toHaveProperty('role');
-    //                 expect(user).toHaveProperty('roomId');
-    //                 expect(user).toHaveProperty('userId');
-    //               });
-    //             });
-    //         }),
-    //     );
-    //   });
-    //   it('from notMember: should return 403 Forbidden', () => {
-    //     return request(app.getHttpServer())
-    //       .get(`/room/${testRoom.roomId}`)
-    //       .set(
-    //         'Authorization',
-    //         `Bearer ${users[UserType.NotMember].accessToken}`,
-    //       )
-    //       .expect(403);
-    //   });
-    //   it('from unAuthorized User: should return 401 Unauthorized', () => {
-    //     return request(app.getHttpServer())
-    //       .get(`/room/${testRoom.roomId}`)
-    //       .expect(401);
-    //   });
-    // });
-    // describe('POST', () => {
-    //   it('from member: should return 409 Conflict', () => {
-    //     return Promise.all(
-    //       users
-    //         .filter((user) => user.role !== undefined)
-    //         .map((user) => {
-    //           return request(app.getHttpServer())
-    //             .post(`/room/${testRoom.roomId}`)
-    //             .set('Authorization', `Bearer ${user.accessToken}`)
-    //             .expect(409);
-    //         }),
-    //     );
-    //   });
-    //   it('from notMember: should return 201 Created', () => {
-    //     return Promise.all(
-    //       users
-    //         .filter((user) => user.role === undefined)
-    //         .map((user) => {
-    //           return request(app.getHttpServer())
-    //             .post(`/room/${testRoom.roomId}`)
-    //             .set('Authorization', `Bearer ${user.accessToken}`)
-    //             .expect(201);
-    //         }),
-    //     ).then(() => {
-    //       return request(app.getHttpServer())
-    //         .get(`/room/${testRoom.roomId}`)
-    //         .set(
-    //           'Authorization',
-    //           `Bearer ${users[UserType.NotMember].accessToken}`,
-    //         )
-    //         .expect(200)
-    //         .then((res) => {
-    //           expect(res.body.users.length).toBe(users.length);
-    //           return request(app.getHttpServer())
-    //             .delete(
-    //               `/room/${testRoom.roomId}/${users[UserType.NotMember].id}`,
-    //             )
-    //             .set(
-    //               'Authorization',
-    //               `Bearer ${users[UserType.owner].accessToken}`,
-    //             )
-    //             .expect(200);
-    //         })
-    //         .then(() => {
-    //           return request(app.getHttpServer())
-    //             .get(`/room/${testRoom.roomId}`)
-    //             .set(
-    //               'Authorization',
-    //               `Bearer ${users[UserType.NotMember].accessToken}`,
-    //             )
-    //             .expect(403);
-    //         });
-    //     });
-    //   });
-    //   it('from unAuthorized User: should return 401 Unauthorized', () => {
-    //     return request(app.getHttpServer())
-    //       .post(`/room/${testRoom.roomId}`)
-    //       .expect(401);
-    //   });
-    // });
-    // describe('PATCH', () => {
-    //   const newName = 'new_name';
-    //   it('from roomMember: Owner : should return 200 OK', () => {
-    //     return Promise.all(
-    //       users
-    //         .filter((user) => user.role === Role.OWNER)
-    //         .map((user) => {
-    //           return request(app.getHttpServer())
-    //             .patch(`/room/${testRoom.roomId}`)
-    //             .set('Authorization', `Bearer ${user.accessToken}`)
-    //             .send({ name: newName })
-    //             .expect(200);
-    //         }),
-    //     ).then(() => {
-    //       return request(app.getHttpServer())
-    //         .get(`/room/${testRoom.roomId}`)
-    //         .set('Authorization', `Bearer ${users[UserType.owner].accessToken}`)
-    //         .expect(200)
-    //         .then((res) => expect(res.body.name).toBe(newName));
-    //     });
-    //   });
-    //   it('from notMember and Member except Owner: should return 403 Forbidden', () => {
-    //     return Promise.all(
-    //       users
-    //         .filter((user) => user.role !== Role.OWNER)
-    //         .map((user) => {
-    //           return request(app.getHttpServer())
-    //             .patch(`/room/${testRoom.roomId}`)
-    //             .set('Authorization', `Bearer ${user.accessToken}`)
-    //             .send({ name: newName })
-    //             .expect(403);
-    //         }),
-    //     );
-    //   });
-    //   it('from unAuthorized User: should return 401 Unauthorized', () => {
-    //     return request(app.getHttpServer())
-    //       .patch(`/room/${testRoom.roomId}`)
-    //       .send({ name: newName })
-    //       .expect(401);
-    //   });
-    // });
+    describe('GET', () => {
+      it('from roomMember: should return the room 200 OK', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+
+        return Promise.all(
+          users
+            .filter((user) => user.name !== 'NotMEMBER')
+            .map((user) => {
+              return request(app.getHttpServer())
+                .get(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${user.accessToken}`)
+                .expect(200)
+                .then((res) => {
+                  expect(res.body).toHaveProperty('id');
+                  expect(res.body).toHaveProperty('name');
+                  expect(res.body).toHaveProperty('users');
+                  expect(res.body.users).toBeInstanceOf(Array);
+                  expect(res.body.users.length).toBeGreaterThan(0);
+                  res.body.users.forEach((user) => {
+                    expect(user).toHaveProperty('id');
+                    expect(user).toHaveProperty('role');
+                    expect(user).toHaveProperty('roomId');
+                    expect(user).toHaveProperty('userId');
+                  });
+                });
+            }),
+        );
+      });
+      it('from notMember: should return 403 Forbidden', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+        const notMember = users.find((u) => u.name === 'NotMEMBER');
+        console.log('user    test!!', users);
+
+        return request(app.getHttpServer())
+          .get(`/room/${room.id}`)
+          .set('Authorization', `Bearer ${notMember.accessToken}`)
+          .expect(403);
+      });
+      it('from unAuthorized User: should return 401 Unauthorized', async () => {
+        const room = await getRoom(createRoomDto.name);
+
+        return request(app.getHttpServer()).get(`/room/${room.id}`).expect(401);
+      });
+    });
+
+    describe('POST', () => {
+      it('from member: should return 409 Conflict', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+
+        return Promise.all(
+          users
+            .filter((user) => user.name !== 'NotMember')
+            .map((user) => {
+              return request(app.getHttpServer())
+                .post(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${user.accessToken}`)
+                .expect(409);
+            }),
+        );
+      });
+      it('from notMember: should return 201 Created', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+        const notMember = users.find((u) => u.name === 'NotMEMBER');
+        const owner = users.find((u) => u.name === 'OWNER');
+
+        return Promise.all(
+          users
+            .filter((user) => user.name === undefined)
+            .map((user) => {
+              return request(app.getHttpServer())
+                .post(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${user.accessToken}`)
+                .expect(201);
+            }),
+        ).then(() => {
+          return request(app.getHttpServer())
+            .get(`/room/${room.id}`)
+            .set('Authorization', `Bearer ${notMember.accessToken}`)
+            .expect(200)
+            .then((res) => {
+              expect(res.body.users.length).toBe(users.length);
+              return request(app.getHttpServer())
+                .delete(`/room/${room.id}/${getUserIdFromJWT(notMember)}`)
+                .set('Authorization', `Bearer ${owner.accessToken}`)
+                .expect(200);
+            })
+            .then(() => {
+              return request(app.getHttpServer())
+                .get(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${notMember.accessToken}`)
+                .expect(403);
+            });
+        });
+      });
+      it('from unAuthorized User: should return 401 Unauthorized', async () => {
+        const room = await getRoom(createRoomDto.name);
+
+        return request(app.getHttpServer())
+          .post(`/room/${room.id}`)
+          .expect(401);
+      });
+    });
+
+    describe('PATCH', () => {
+      const newName = 'new_name';
+      it('from roomMember: Owner : should return 200 OK', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+        const owner = users.find((u) => u.name === 'OWNER');
+
+        return Promise.all(
+          users
+            .filter((user) => user.name === Role.OWNER)
+            .map((user) => {
+              return request(app.getHttpServer())
+                .patch(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${user.accessToken}`)
+                .send({ name: newName })
+                .expect(200);
+            }),
+        ).then(() => {
+          return request(app.getHttpServer())
+            .get(`/room/${room.id}`)
+            .set('Authorization', `Bearer ${owner.accessToken}}`)
+            .expect(200)
+            .then((res) => expect(res.body.name).toBe(newName));
+        });
+      });
+      it('from notMember and Member except Owner: should return 403 Forbidden', async () => {
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
+        const room = await getRoom(createRoomDto.name);
+
+        return Promise.all(
+          users
+            .filter((user) => user.name !== Role.OWNER)
+            .map((user) => {
+              return request(app.getHttpServer())
+                .patch(`/room/${room.id}`)
+                .set('Authorization', `Bearer ${user.accessToken}`)
+                .send({ name: newName })
+                .expect(403);
+            }),
+        );
+      });
+      it('from unAuthorized User: should return 401 Unauthorized', async () => {
+        const room = await getRoom(createRoomDto.name);
+
+        return request(app.getHttpServer())
+          .patch(`/room/${room.id}`)
+          .send({ name: newName })
+          .expect(401);
+      });
+    });
 
     describe('DELETE', () => {
       it('from roomMember: Owner : should return 200 OK (to prepare test, this action is tried. To prevent room delete, don"t execute this test! take care!)', () => {
         return expect(true).toBe(true);
       });
       it('from notMember and Member except Owner: should return 403 Forbidden', async () => {
-        const usersLoginPromise = Promise.all(
-          userDtos.map((u) => loginUser(u)),
-        );
-        const users = await usersLoginPromise;
+        const users = await Promise.all(userDtos.map((u) => loginUser(u)));
         const room = await getRoom(createRoomDto.name);
 
         return Promise.all(

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -268,7 +268,11 @@ describe('AppController (e2e)', () => {
         .post('/room')
         .set('Authorization', `Bearer ${user.accessToken}`)
         .send(createRoomDto)
-        .then((res) => res.body);
+        .then((res) => {
+          const expectedProps: (keyof RoomEntity)[] = ['id', 'name'];
+          const isRoomEntity = expectedProps.every((prop) => prop in res.body);
+          return isRoomEntity ? res.body : Promise.reject(res.body);
+        });
 
     const enterRoom = (
       user: UserWithToken,
@@ -278,7 +282,16 @@ describe('AppController (e2e)', () => {
         .post(`/room/${room.id}`)
         .set('Authorization', `Bearer ${user.accessToken}`)
         .send()
-        .then((res) => ({ ...res.body, ...user }));
+        .then((res) => {
+          const expectedProps: (keyof UserOnRoomEntity)[] = [
+            'id',
+            'role',
+            'userId',
+            'roomId',
+          ];
+          const isMember = expectedProps.every((prop) => prop in res.body);
+          return isMember ? { ...res.body, ...user } : Promise.reject(res.body);
+        });
 
     const payloadFromJWT = ({ accessToken }: { accessToken: string }) =>
       atob(accessToken.split('.')[1]);
@@ -288,10 +301,13 @@ describe('AppController (e2e)', () => {
         .post('/auth/login')
         .send(user)
         .then((res) => {
-          return {
-            ...user,
-            accessToken: res.body.accessToken,
-          };
+          const expectedProps: (keyof AuthEntity)[] = ['accessToken'];
+          const isUserWithToken = expectedProps.every(
+            (prop) => prop in res.body,
+          );
+          return isUserWithToken
+            ? { ...res.body, ...user }
+            : Promise.reject(res.body);
         });
     };
 

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -23,7 +23,7 @@ describe('AppController (e2e)', () => {
   };
   const testUserLogin = { email: testUser.email, password: testUser.password };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -554,15 +554,15 @@ describe('AppController (e2e)', () => {
 
         return testPatch(notMembers, 403, room, { name: newName });
       });
-    });
-    //   it('from unAuthorized User: should return 401 Unauthorized', async () => {
-    //     const room = await getRoom(createRoomDto.name);
+      it('from unAuthorized User: should return 401 Unauthorized', async () => {
+        const room = await getRoom(createRoomDto.name);
 
-    //     return request(app.getHttpServer())
-    //       .patch(`/room/${room.id}`)
-    //       .send({ name: newName })
-    //       .expect(401);
-    //   });
+        return request(app.getHttpServer())
+          .patch(`/room/${room.id}`)
+          .send({ name: newName })
+          .expect(401);
+      });
+    });
     // });
 
     // describe('DELETE', () => {

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -368,11 +368,6 @@ describe('AppController (e2e)', () => {
           const isUserEntity = expectedProps.every((prop) => prop in res.body);
           return isUserEntity ? res.body : Promise.reject(res.body);
         });
-    const getUsers = () => {
-      return request(app.getHttpServer())
-        .get('/user')
-        .then((res) => res.body);
-    };
 
     beforeAll(async () => {
       let room;


### PR DESCRIPTION
refactor 
more functional programming

テストのそれぞれの関数内で、毎回API でuser を取得しているが、仕方ない?
それを回避するには let users みたいなのを 親のネストでやるのか。それはここまで来て気持ち悪い。

あと、通っていたテストが通らなくなったり、テストの結果が毎回異なっていたりする。
多分どこかで非同期処理がミスっているのでそれを訂正します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved error handling in room removal operations.
  - Streamlined user search within a room for better performance.
  - Optimized user role updates in room management.

- **Tests**
  - Enhanced end-to-end testing with new user and room management functions.
  - Implemented more robust authentication and authorization test cases.
  - Updated test suite to reflect new user and room data structures and workflows.

- **Chores**
  - Adjusted data seeding scripts to ensure idempotent user and room creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->