### PR TITLE
[frontend] Print jose error message instead of stack trace (#82)

### DIFF
--- a/frontend/app/lib/session.ts
+++ b/frontend/app/lib/session.ts
@@ -41,7 +41,11 @@ async function getAccessTokenPayload(options: any) {
     });
     return payload;
   } catch (e) {
-    console.log("jwt token is invalid: ", e);
+    if (e instanceof jose.errors.JOSEError) {
+      console.log("jose error: ", e.message);
+    } else {
+      console.log("unknown error: ", e);
+    }
     return null;
   }
 }


### PR DESCRIPTION
Fix #82
とりあえずエラー表示は1行で収まるようにした
<img width="621" alt="Screenshot 2023-12-03 at 14 42 38" src="https://github.com/usatie/pong/assets/7609060/d2a2eb35-9ef3-4bd6-a7b3-3177adc250bb">
