### PR TITLE
Feat/dm/logging message

### DIFF
--- a/backend/src/chat/chat.controller.spec.ts
+++ b/backend/src/chat/chat.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+
+describe('ChatController', () => {
+  let controller: ChatController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatController],
+      providers: [ChatService],
+    }).compile();
+
+    controller = module.get<ChatController>(ChatController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/chat/chat.controller.spec.ts
+++ b/backend/src/chat/chat.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('ChatController', () => {
   let controller: ChatController;
@@ -8,7 +9,7 @@ describe('ChatController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChatController],
-      providers: [ChatService],
+      providers: [ChatService, PrismaService],
     }).compile();
 
     controller = module.get<ChatController>(ChatController);

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -20,13 +20,13 @@ export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
   @Post()
-  create(@Body() createChatDto: CreateChatDto) {
-    return this.chatService.create(createChatDto);
+  createConversation(@Body() createChatDto: CreateChatDto) {
+    return this.chatService.createConversation(createChatDto);
   }
 
   @Get()
-  findAll(@Query() createChatDto: CreateChatDto) {
-    return this.chatService.findAll(createChatDto);
+  findConversation(@Query() createChatDto: CreateChatDto) {
+    return this.chatService.findConversation(createChatDto);
   }
 
   //  @Get(':id')

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  //  Patch,
+  Param,
+  //  Delete,
+} from '@nestjs/common';
+import { ChatService } from './chat.service';
+import { CreateChatDto } from './dto/create-chat.dto';
+//import { UpdateChatDto } from './dto/update-chat.dto';
+import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
+import { ApiTags } from '@nestjs/swagger';
+
+@Controller('chat')
+@ApiTags('chat')
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  @Post()
+  create(@Body() createChatDto: CreateChatDto) {
+    return this.chatService.create(createChatDto);
+  }
+
+  @Get()
+  findAll(@Query() createChatDto: CreateChatDto) {
+    return this.chatService.findAll(createChatDto);
+  }
+
+  //  @Get(':id')
+  //  findOne(@Param('id') id: string) {
+  //    return this.chatService.findOne(+id);
+  //  }
+  //
+  //  @Patch(':id')
+  //  update(@Param('id') id: string, @Body() updateChatDto: UpdateChatDto) {
+  //    return this.chatService.update(+id, updateChatDto);
+  //  }
+  //
+  //  @Delete(':id')
+  //  remove(@Param('id') id: string) {
+  //    return this.chatService.remove(+id);
+  //  }
+
+  @Post(':id')
+  createDirectMessage(
+    @Param('id') id: string,
+    @Body() createDirectMessageDto: CreateDirectMessageDto,
+  ) {
+    return this.chatService.createDirectMessage(+id, createDirectMessageDto);
+  }
+}

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -1,7 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ChatService } from './chat.service';
+import { ChatController } from './chat.controller';
 import { ChatGateway } from './chat.gateway';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
 @Module({
-  providers: [ChatGateway],
+  controllers: [ChatController],
+  providers: [ChatGateway, ChatService],
+  imports: [PrismaModule],
 })
 export class ChatModule {}

--- a/backend/src/chat/chat.service.spec.ts
+++ b/backend/src/chat/chat.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatService } from './chat.service';
+
+describe('ChatService', () => {
+  let service: ChatService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChatService],
+    }).compile();
+
+    service = module.get<ChatService>(ChatService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/chat/chat.service.spec.ts
+++ b/backend/src/chat/chat.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatService } from './chat.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('ChatService', () => {
   let service: ChatService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ChatService],
+      providers: [ChatService, PrismaService],
     }).compile();
 
     service = module.get<ChatService>(ChatService);

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -8,11 +8,11 @@ import { PrismaService } from 'src/prisma/prisma.service';
 export class ChatService {
   constructor(private prisma: PrismaService) {}
 
-  create(createChatDto: CreateChatDto) {
+  createConversation(createChatDto: CreateChatDto) {
     return this.prisma.conversation.create({ data: createChatDto });
   }
 
-  findAll(createChatDto: CreateChatDto) {
+  findConversation(createChatDto: CreateChatDto) {
     return this.prisma.conversation.findFirstOrThrow({
       where: {
         AND: [
@@ -42,8 +42,6 @@ export class ChatService {
     conversationId: number,
     createDirectMessageDto: CreateDirectMessageDto,
   ) {
-    console.log(conversationId);
-    console.log(createDirectMessageDto);
     return this.prisma.directMessage.create({
       data: {
         conversationId: conversationId,

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { CreateChatDto } from './dto/create-chat.dto';
+//import { UpdateChatDto } from './dto/update-chat.dto';
+import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ChatService {
+  constructor(private prisma: PrismaService) {}
+
+  create(createChatDto: CreateChatDto) {
+    return this.prisma.conversation.create({ data: createChatDto });
+  }
+
+  findAll(createChatDto: CreateChatDto) {
+    return this.prisma.conversation.findFirstOrThrow({
+      where: {
+        AND: [
+          { userOneId: createChatDto.userOneId },
+          { userTwoId: createChatDto.userTwoId },
+        ],
+      },
+      include: {
+        directmessages: true,
+      },
+    });
+  }
+
+  //  findOne(id: number) {
+  //    return `This action returns a #${id} chat`;
+  //  }
+  //
+  //  update(id: number, updateChatDto: UpdateChatDto) {
+  //    return `This action updates a #${id} chat`;
+  //  }
+  //
+  //  remove(id: number) {
+  //    return `This action removes a #${id} chat`;
+  //  }
+
+  async createDirectMessage(
+    conversationId: number,
+    createDirectMessageDto: CreateDirectMessageDto,
+  ) {
+    console.log(conversationId);
+    console.log(createDirectMessageDto);
+    return this.prisma.directMessage.create({
+      data: {
+        conversationId: conversationId,
+        content: createDirectMessageDto.content,
+        userName: createDirectMessageDto.userName,
+      },
+    });
+  }
+}

--- a/backend/src/chat/dto/create-chat.dto.ts
+++ b/backend/src/chat/dto/create-chat.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
-//import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateChatDto {
   @IsNotEmpty()

--- a/backend/src/chat/dto/create-chat.dto.ts
+++ b/backend/src/chat/dto/create-chat.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+//import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateChatDto {
+  @IsNotEmpty()
+  @ApiProperty()
+  userOneId: string;
+
+  @IsNotEmpty()
+  @ApiProperty()
+  userTwoId: string;
+}

--- a/backend/src/chat/dto/create-direct-message.dto.ts
+++ b/backend/src/chat/dto/create-direct-message.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateDirectMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  content: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  userName: string;
+
+  @IsString()
+  @ApiProperty({ required: false })
+  conversationId?: string;
+
+  @IsString()
+  @ApiProperty({ required: false })
+  from?: string;
+
+  @IsString()
+  @ApiProperty({ required: false })
+  to?: string;
+}

--- a/backend/src/chat/dto/update-chat.dto.ts
+++ b/backend/src/chat/dto/update-chat.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateChatDto } from './create-chat.dto';
+
+export class UpdateChatDto extends PartialType(CreateChatDto) {}

--- a/backend/src/chat/entities/chat.entity.ts
+++ b/backend/src/chat/entities/chat.entity.ts
@@ -1,0 +1,1 @@
+export class Chat {}

--- a/frontend/app/direct-message/[directMessageId]/page.tsx
+++ b/frontend/app/direct-message/[directMessageId]/page.tsx
@@ -1,6 +1,11 @@
 import ChatRoomCard from "@/app/ui/direct-message/chat-room";
 import { getUserId } from "@/app/lib/session";
-import { getUsers, getUser } from "@/app/lib/actions";
+import {
+  getUsers,
+  getUser,
+  getConversation,
+  createConversation,
+} from "@/app/lib/actions";
 import type { User } from "@/app/ui/user/card";
 import { notFound } from "next/navigation";
 
@@ -26,5 +31,32 @@ export default async function Page({
   if (!otherUser || otherUser.id === parseInt(currentUserId)) {
     notFound();
   }
-  return <ChatRoomCard me={currentUser} other={otherUser} />;
+  let conversation =
+    (await getConversation(String(currentUserId), String(otherUser.id))) ||
+    (await getConversation(String(otherUser.id), String(currentUserId)));
+  if (!conversation) {
+    const res = await createConversation(
+      String(currentUserId),
+      String(otherUser.id),
+    );
+    if (!res) {
+      throw new Error("createConversation error");
+    }
+    conversation = await getConversation(
+      String(currentUserId),
+      String(otherUser.id),
+    );
+    if (!conversation) {
+      throw new Error("getConversation error");
+    }
+  }
+  console.log(conversation);
+  return (
+    <ChatRoomCard
+      id={conversation.id}
+      oldLog={conversation.directmessages}
+      me={currentUser}
+      other={otherUser}
+    />
+  );
 }

--- a/frontend/app/direct-message/[directMessageId]/page.tsx
+++ b/frontend/app/direct-message/[directMessageId]/page.tsx
@@ -32,16 +32,13 @@ export default async function Page({
     notFound();
   }
   let conversation =
-    (await getConversation(String(currentUserId), String(otherUser.id))) ||
+    (await getConversation(String(currentUserId), String(otherUser.id))) ??
     (await getConversation(String(otherUser.id), String(currentUserId)));
   if (!conversation) {
     const res = await createConversation(
       String(currentUserId),
       String(otherUser.id),
     );
-    if (!res) {
-      throw new Error("createConversation error");
-    }
     conversation = await getConversation(
       String(currentUserId),
       String(otherUser.id),

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -196,9 +196,11 @@ export async function getConversation(userOneId: string, userTwoId: string) {
       cache: "no-cache",
     },
   );
-  if (!res.ok) {
-    console.error("getConversation error: ", await res.json());
+  if (res.status === 404) {
     return null;
+  } else if (!res.ok) {
+    console.error("getConversation error: ", await res.json());
+    throw new Error("createConversation error");
   } else {
     const conversation = await res.json();
     return conversation;
@@ -217,8 +219,8 @@ export async function createConversation(userOneId: string, userTwoId: string) {
     }),
   });
   if (!res.ok) {
-    console.error("createRoom error: ", await res.json());
-    return null;
+    console.error("createConversation error: ", await res.json());
+    throw new Error("createConversation error");
   } else {
     const newConversation = await res.json();
     return newConversation;

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -188,3 +188,38 @@ export async function joinRoom(
     redirect(`/room/${roomId}`, RedirectType.push);
   }
 }
+
+export async function getConversation(userOneId: string, userTwoId: string) {
+  const res = await fetch(
+    `${process.env.API_URL}/chat?userOneId=${userOneId}&userTwoId=${userTwoId}`,
+    {
+      cache: "no-cache",
+    },
+  );
+  if (!res.ok) {
+    console.error("getConversation error: ", await res.json());
+    return null;
+  } else {
+    const conversation = await res.json();
+    return conversation;
+  }
+}
+
+export async function createConversation(userOneId: string, userTwoId: string) {
+  const res = await fetch(`${process.env.API_URL}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      userOneId,
+      userTwoId,
+    }),
+  });
+  if (!res.ok) {
+    console.error("createRoom error: ", await res.json());
+  } else {
+    const newConversation = await res.json();
+    return newConversation;
+  }
+}

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -218,6 +218,7 @@ export async function createConversation(userOneId: string, userTwoId: string) {
   });
   if (!res.ok) {
     console.error("createRoom error: ", await res.json());
+    return null;
   } else {
     const newConversation = await res.json();
     return newConversation;


### PR DESCRIPTION
[backend]
- DMのcreateとreadのAPIを作成しました。
- DMを受信した時にDBへ書き込むように変更しました。

[frontend]
- lib/actions.tsにDMのcreateとreadのAPIを叩く関数を追加しました。
- 各ユーザーへのDM pageを開いた際に過去のログの取得(無ければ作成)をしてそれまでのメッセージログを表示できるように変更しました。

backendは必要最低限のものだけ作成し、それ以外はコメントアウトしています。(PATCH、DELETEなど)
取り敢えず過去ログを表示できるようにしようとしていたので、現状はbackend、frontend共に要修正 and リファクタリングなコードになっています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced direct messaging capabilities within the chat system.
  - Added new functions for fetching and creating chat conversations.

- **Bug Fixes**
  - Adjusted conversation retrieval and creation logic to handle errors more effectively.

- **Documentation**
  - Updated Swagger annotations for chat-related data transfer objects (DTOs).

- **Refactor**
  - Streamlined chat controller by removing unused methods.
  - Enhanced chat service with new direct message creation method.

- **Tests**
  - Added test suites for chat controller and chat service to ensure proper initialization.

- **Style**
  - Updated message type structure to include `conversationId` for direct messaging.

- **Chores**
  - Expanded chat module with new service and controller imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->