### PR TITLE
[frontend] add logic to /chat

### DIFF
--- a/frontend/app/chat/[id]/page.tsx
+++ b/frontend/app/chat/[id]/page.tsx
@@ -1,15 +1,19 @@
 import { Separator } from "@/components/ui/separator";
-import { testData } from "./test-data";
-import { Sidebar } from "./sidebar";
-import MessageArea from "./message-area";
+import { testData } from "../test-data";
+import { Sidebar } from "../sidebar";
+import MessageArea from "../message-area";
 import { getUserId } from "@/app/lib/session";
-import { getUsers } from "@/app/lib/actions";
+import { getUser, getUsers } from "@/app/lib/actions";
 
 //async function getUsers() {
 //  return testData.users;
 //}
 
-export default async function ChatPage() {
+export default async function ChatPage({
+  params: { id },
+}: {
+  params: { id: string };
+}) {
   const [tmpUsers, currentUserId] = await Promise.all([
     getUsers(),
     getUserId(),
@@ -17,8 +21,15 @@ export default async function ChatPage() {
   if (!currentUserId) {
     throw new Error("getUserId error");
   }
+  const currentUser = await getUser(parseInt(currentUserId));
   const users = tmpUsers.filter((user) => user.id !== parseInt(currentUserId));
   if (!users) {
+    console.error("users error");
+    return null;
+  }
+  const otherUser = users.find((user) => String(user.id) === id);
+  if (!otherUser) {
+    console.error("other error");
     return null;
   }
   return (
@@ -26,6 +37,7 @@ export default async function ChatPage() {
       <div className="overflow-auto flex-grow flex gap-4 pb-4">
         <Sidebar users={users} />
         <Separator orientation="vertical" />
+        <MessageArea me={currentUser} other={otherUser} />
       </div>
     </>
   );

--- a/frontend/app/chat/[id]/page.tsx
+++ b/frontend/app/chat/[id]/page.tsx
@@ -23,14 +23,14 @@ export default async function ChatPage({
   }
   const currentUser = await getUser(parseInt(currentUserId));
   const users = tmpUsers.filter((user) => user.id !== parseInt(currentUserId));
-  if (!users) {
-    console.error("users error");
-    return null;
+  if (users.length === 0) {
+    console.error("No other users exist");
+    throw new Error("No other users exist");
   }
   const otherUser = users.find((user) => String(user.id) === id);
   if (!otherUser) {
-    console.error("other error");
-    return null;
+    console.error("Can't find the other user");
+    throw new Error("Can't find the other user");
   }
   return (
     <>

--- a/frontend/app/chat/helper.ts
+++ b/frontend/app/chat/helper.ts
@@ -7,7 +7,7 @@ export function groupMessagesByUser(messages: Message[]): Message[][] {
   let currentGroup: Message[] = [];
 
   for (const msg of messages) {
-    if (msg.user_id === prevUserId) {
+    if (parseInt(msg.from) === prevUserId) {
       currentGroup.push(msg);
     } else {
       if (currentGroup.length) {
@@ -15,7 +15,7 @@ export function groupMessagesByUser(messages: Message[]): Message[][] {
       }
       currentGroup = [msg];
     }
-    prevUserId = msg.user_id;
+    prevUserId = parseInt(msg.from);
   }
 
   if (currentGroup.length) {

--- a/frontend/app/chat/message-area.tsx
+++ b/frontend/app/chat/message-area.tsx
@@ -59,10 +59,6 @@ function MessageArea({ me, other }: { me: User; other: User }) {
   const myId = me.id.toString();
   const otherId = other.id.toString();
 
-  console.log("myId", myId);
-  console.log(typeof myId);
-  console.log("otherId", otherId);
-  console.log(typeof otherId);
   // TODO: Messageを取得するsocketのロジック等を実装
   // メッセージを取得
   useEffect(() => {
@@ -84,7 +80,7 @@ function MessageArea({ me, other }: { me: User; other: User }) {
       console.log("disconnect");
       socket.disconnect();
     };
-  }, []);
+  }, [myId, otherId]);
 
   const didLogRef = useRef(false);
   useEffect(() => {
@@ -94,13 +90,12 @@ function MessageArea({ me, other }: { me: User; other: User }) {
         const conversation = await getMessages(myId, otherId);
         const messages = conversation.directmessages;
         const id = conversation.id;
-        console.log(id);
         setMessages(messages);
         setId(id);
       };
       fetchMessages();
     }
-  }, []);
+  }, [myId, otherId]);
   const messageGroups = groupMessagesByUser(messages);
   const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
   const isScrolledToBottom = useScrollToBottom(contentRef, messages);
@@ -114,7 +109,6 @@ function MessageArea({ me, other }: { me: User; other: User }) {
       const name = me.name;
       const fromId = myId;
       const toId = otherId;
-      console.log(id);
       socket.emit("privateMessage", {
         conversationId: id,
         from: fromId,

--- a/frontend/app/chat/message-area.tsx
+++ b/frontend/app/chat/message-area.tsx
@@ -6,34 +6,124 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { testData } from "./test-data";
 import type { Message } from "./test-data";
+import type { User } from "@/app/ui/user/card";
 import { MessageSkeleton } from "./skeleton";
 import { groupMessagesByUser, useScrollToBottom } from "./helper";
+import { chatSocket as socket } from "@/socket";
+import { getConversation, createConversation } from "@/app/lib/actions";
+import * as z from "zod";
 
-async function getMessages() {
+async function getMessages(myId: string, otherId: string) {
   // TODO: Implement this function
-  return testData.messages;
+  let conversation =
+    (await getConversation(myId, otherId)) ??
+    (await getConversation(otherId, myId));
+  console.log(conversation);
+  if (!conversation) {
+    const res = await createConversation(myId, otherId);
+    conversation = await getConversation(myId, otherId);
+    console.log(conversation);
+    if (!conversation) {
+      throw new Error("getConversation error");
+    }
+  }
+  return conversation;
 }
 
-function MessageArea() {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const messageGroups = groupMessagesByUser(messages);
-  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
-  const isScrolledToBottom = useScrollToBottom(contentRef, messages);
+type TextInputProps = {
+  sendMessage: (e: React.SyntheticEvent) => void;
+  setMessage: (message: string) => void;
+  message: string;
+};
+function TextInput({ sendMessage, setMessage, message }: TextInputProps) {
+  return (
+    <form className="flex gap-4" id="chat-content" onSubmit={sendMessage}>
+      <Input
+        placeholder="Message..."
+        name="message"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        type="text"
+      />
+      <Button type="submit">Send</Button>
+    </form>
+  );
+}
 
+const formSchema = z.string().min(1);
+
+function MessageArea({ me, other }: { me: User; other: User }) {
+  const [message, setMessage] = useState("");
+  const [id, setId] = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const myId = me.id.toString();
+  const otherId = other.id.toString();
+
+  console.log("myId", myId);
+  console.log(typeof myId);
+  console.log("otherId", otherId);
+  console.log(typeof otherId);
   // TODO: Messageを取得するsocketのロジック等を実装
   // メッセージを取得
   useEffect(() => {
-    const fetchMessages = async () => {
-      const messages = await getMessages();
-      setMessages(messages);
+    socket.connect();
+    socket.emit("joinDM", myId);
+
+    const handleMessageReceived = (newMessage: Message) => {
+      if (newMessage.from === otherId || newMessage.from === myId) {
+        console.log("received message: ", newMessage);
+        setMessages((oldMessages) => [...oldMessages, newMessage]);
+        console.log(newMessage);
+      }
     };
-    fetchMessages();
+
+    socket.on("sendToUser", handleMessageReceived);
+    return () => {
+      console.log(`return from useEffect`);
+      socket.off("sendToUser", handleMessageReceived);
+      console.log("disconnect");
+      socket.disconnect();
+    };
   }, []);
+
+  const didLogRef = useRef(false);
+  useEffect(() => {
+    if (didLogRef.current === false) {
+      didLogRef.current = true;
+      const fetchMessages = async () => {
+        const conversation = await getMessages(myId, otherId);
+        const messages = conversation.directmessages;
+        const id = conversation.id;
+        console.log(id);
+        setMessages(messages);
+        setId(id);
+      };
+      fetchMessages();
+    }
+  }, []);
+  const messageGroups = groupMessagesByUser(messages);
+  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const isScrolledToBottom = useScrollToBottom(contentRef, messages);
 
   const sendMessage = (e: React.SyntheticEvent) => {
     // TODO: Implement this function
     e.preventDefault();
     console.log("sendMessage");
+    const result = formSchema.safeParse(message);
+    if (result.success) {
+      const name = me.name;
+      const fromId = myId;
+      const toId = otherId;
+      console.log(id);
+      socket.emit("privateMessage", {
+        conversationId: id,
+        from: fromId,
+        to: toId,
+        userName: name,
+        content: message,
+      });
+      setMessage("");
+    }
   };
 
   return (
@@ -53,15 +143,18 @@ function MessageArea() {
         }`}
       >
         <Stack spacing={4}>
-          {messageGroups.map((group) => (
-            <MessageGroup messages={group} key={group[0].id} />
+          {messageGroups.map((group, index) => (
+            <MessageGroup messages={group} key={index} />
           ))}
         </Stack>
       </div>
       {/* メッセージ入力エリア */}
-      <div className="flex gap-4">
-        <Input placeholder="Type message here" />
-        <Button onClick={sendMessage}>Send</Button>
+      <div>
+        <TextInput
+          setMessage={setMessage}
+          message={message}
+          sendMessage={sendMessage}
+        />
       </div>
     </div>
   );

--- a/frontend/app/chat/message-area.tsx
+++ b/frontend/app/chat/message-area.tsx
@@ -56,6 +56,9 @@ function MessageArea({ me, other }: { me: User; other: User }) {
   const [message, setMessage] = useState("");
   const [id, setId] = useState("");
   const [messages, setMessages] = useState<Message[]>([]);
+  const messageGroups = groupMessagesByUser(messages);
+  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const isScrolledToBottom = useScrollToBottom(contentRef, messages);
   const myId = me.id.toString();
   const otherId = other.id.toString();
 
@@ -96,9 +99,6 @@ function MessageArea({ me, other }: { me: User; other: User }) {
       fetchMessages();
     }
   }, [myId, otherId]);
-  const messageGroups = groupMessagesByUser(messages);
-  const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
-  const isScrolledToBottom = useScrollToBottom(contentRef, messages);
 
   const sendMessage = (e: React.SyntheticEvent) => {
     // TODO: Implement this function

--- a/frontend/app/chat/message-group.tsx
+++ b/frontend/app/chat/message-group.tsx
@@ -6,7 +6,7 @@ export function MessageGroup({ messages }: { messages: Message[] }) {
   return (
     <Stack spacing={1}>
       {messages.map((msg, i) => {
-        return <MessageItem message={msg} withAvatar={i === 0} key={msg.id} />;
+        return <MessageItem message={msg} withAvatar={i === 0} key={i} />;
       })}
     </Stack>
   );

--- a/frontend/app/chat/message-item.tsx
+++ b/frontend/app/chat/message-item.tsx
@@ -9,7 +9,7 @@ export function MessageItem({
   message: Message;
   withAvatar: boolean;
 }) {
-  const created_at_hhmm = message.created_at.split(" ")[1].slice(0, 5);
+  //  const created_at_hhmm = message.created_at.split(" ")[1].slice(0, 5);
 
   return (
     <HStack spacing={4} className="group hover:opacity-60">
@@ -17,20 +17,20 @@ export function MessageItem({
       {withAvatar && <AvatarSkeleton />}
       {!withAvatar && (
         <div className="group-hover:text-muted-foreground flex-none text-background text-xs w-10 text-center">
-          <span>{created_at_hhmm}</span>
+          {/* <span>{created_at_hhmm}</span> */}
         </div>
       )}
       {/* Right Side */}
       <Stack>
         {withAvatar && (
           <HStack spacing={2}>
-            <div className="text-xs">{message.user_name}</div>
+            <div className="text-xs">{message.userName}</div>
             <div className="text-xs text-muted-foreground">
-              {message.created_at}
+              {/* message.created_at */}
             </div>
           </HStack>
         )}
-        <div className="text-sm text-muted-foreground">{message.text}</div>
+        <div className="text-sm text-muted-foreground">{message.content}</div>
       </Stack>
     </HStack>
   );

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,5 +1,5 @@
 import { Separator } from "@/components/ui/separator";
-import { testData } from "./test-data";
+//import { testData } from "./test-data";
 import { Sidebar } from "./sidebar";
 import MessageArea from "./message-area";
 import { getUserId } from "@/app/lib/session";

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -18,9 +18,6 @@ export default async function ChatPage() {
     throw new Error("getUserId error");
   }
   const users = tmpUsers.filter((user) => user.id !== parseInt(currentUserId));
-  if (!users) {
-    return null;
-  }
   return (
     <>
       <div className="overflow-auto flex-grow flex gap-4 pb-4">

--- a/frontend/app/chat/sidebar-button.tsx
+++ b/frontend/app/chat/sidebar-button.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { SmallAvatarSkeleton } from "./skeleton";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { Stack } from "@/app/ui/layout/stack";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { chatSocket as socket } from "@/socket";
+import type { User } from "@/app/ui/user/card";
+
+function truncateString(str: string | undefined, num: number): string {
+  if (!str) {
+    return "";
+  }
+  if (str.length <= num) {
+    return str;
+  }
+  return str.slice(0, num) + "...";
+}
+
+export function SidebarButton({ user }: { user: User }) {
+  const router = useRouter();
+  const [isBlocked, setIsBlocked] = useState(false);
+
+  const handleOnClick = (user: User) => {
+    router.push(`/chat/${user.id}`);
+  };
+
+  const blockUser = (user: User) => {
+    socket.emit("block", user.id);
+    setIsBlocked(true);
+  };
+
+  const unblockUser = (user: User) => {
+    socket.emit("unblock", user.id);
+    setIsBlocked(false);
+  };
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <button
+            onClick={() => handleOnClick(user)}
+            className="flex gap-2 items-center group hover:opacity-60"
+          >
+            <SmallAvatarSkeleton />
+            <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
+              {truncateString(user.name, 15)}
+            </span>
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-56">
+          <ContextMenuItem inset>Go profile</ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem inset disabled={isBlocked}>
+            <button onClick={() => blockUser(user)}>Block</button>
+          </ContextMenuItem>
+          <ContextMenuItem inset disabled={!isBlocked}>
+            <button onClick={() => unblockUser(user)}>Unblock</button>
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </>
+  );
+}

--- a/frontend/app/chat/sidebar.tsx
+++ b/frontend/app/chat/sidebar.tsx
@@ -2,8 +2,17 @@
 
 import { Stack } from "@/app/ui/layout/stack";
 import { SmallAvatarSkeleton } from "./skeleton";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import type { User } from "@/app/ui/user/card";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { chatSocket as socket } from "@/socket";
 
 function truncateString(str: string | undefined, num: number): string {
   if (!str) {
@@ -18,23 +27,49 @@ function truncateString(str: string | undefined, num: number): string {
 export function Sidebar({ users }: { users: User[] }) {
   // TODO: If users is empty, show a message like "No users found"
   const router = useRouter();
+  const [isBlocked, setIsBlocked] = useState(false);
+
   const handleOnClick = (user: User) => {
     router.push(`/chat/${user.id}`);
   };
+
+  const blockUser = (user: User) => {
+    socket.emit("block", user.id);
+    setIsBlocked(true);
+  };
+
+  const unblockUser = (user: User) => {
+    socket.emit("unblock", user.id);
+    setIsBlocked(false);
+  };
+
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4">
       <Stack spacing={2}>
         {users.map((user) => (
-          <button
-            key={user.id}
-            onClick={() => handleOnClick(user)}
-            className="flex gap-2 items-center group hover:opacity-60"
-          >
-            <SmallAvatarSkeleton />
-            <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
-              {truncateString(user.name, 15)}
-            </span>
-          </button>
+          <ContextMenu key={user.id}>
+            <ContextMenuTrigger>
+              <button
+                onClick={() => handleOnClick(user)}
+                className="flex gap-2 items-center group hover:opacity-60"
+              >
+                <SmallAvatarSkeleton />
+                <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
+                  {truncateString(user.name, 15)}
+                </span>
+              </button>
+            </ContextMenuTrigger>
+            <ContextMenuContent className="w-56">
+              <ContextMenuItem inset>Go profile</ContextMenuItem>
+              <ContextMenuSeparator />
+              <ContextMenuItem inset disabled={isBlocked}>
+                <button onClick={() => blockUser(user)}>Block</button>
+              </ContextMenuItem>
+              <ContextMenuItem inset disabled={!isBlocked}>
+                <button onClick={() => unblockUser(user)}>Unblock</button>
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         ))}
       </Stack>
     </div>

--- a/frontend/app/chat/sidebar.tsx
+++ b/frontend/app/chat/sidebar.tsx
@@ -1,75 +1,23 @@
-"use client";
-
 import { Stack } from "@/app/ui/layout/stack";
-import { SmallAvatarSkeleton } from "./skeleton";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
 import type { User } from "@/app/ui/user/card";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { chatSocket as socket } from "@/socket";
-
-function truncateString(str: string | undefined, num: number): string {
-  if (!str) {
-    return "";
-  }
-  if (str.length <= num) {
-    return str;
-  }
-  return str.slice(0, num) + "...";
-}
+import { SidebarButton } from "./sidebar-button";
 
 export function Sidebar({ users }: { users: User[] }) {
   // TODO: If users is empty, show a message like "No users found"
-  const router = useRouter();
-  const [isBlocked, setIsBlocked] = useState(false);
-
-  const handleOnClick = (user: User) => {
-    router.push(`/chat/${user.id}`);
-  };
-
-  const blockUser = (user: User) => {
-    socket.emit("block", user.id);
-    setIsBlocked(true);
-  };
-
-  const unblockUser = (user: User) => {
-    socket.emit("unblock", user.id);
-    setIsBlocked(false);
-  };
-
+  if (users.length === 0) {
+    return (
+      <div className="overflow-y-auto shrink-0 basis-36 pb-4">
+        <span className="text-muted-foreground text-sm whitespace-nowrap">
+          No users found
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4">
       <Stack spacing={2}>
         {users.map((user) => (
-          <ContextMenu key={user.id}>
-            <ContextMenuTrigger>
-              <button
-                onClick={() => handleOnClick(user)}
-                className="flex gap-2 items-center group hover:opacity-60"
-              >
-                <SmallAvatarSkeleton />
-                <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
-                  {truncateString(user.name, 15)}
-                </span>
-              </button>
-            </ContextMenuTrigger>
-            <ContextMenuContent className="w-56">
-              <ContextMenuItem inset>Go profile</ContextMenuItem>
-              <ContextMenuSeparator />
-              <ContextMenuItem inset disabled={isBlocked}>
-                <button onClick={() => blockUser(user)}>Block</button>
-              </ContextMenuItem>
-              <ContextMenuItem inset disabled={!isBlocked}>
-                <button onClick={() => unblockUser(user)}>Unblock</button>
-              </ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
+          <SidebarButton user={user} key={user.id} />
         ))}
       </Stack>
     </div>

--- a/frontend/app/chat/sidebar.tsx
+++ b/frontend/app/chat/sidebar.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import { Stack } from "@/app/ui/layout/stack";
 import { SmallAvatarSkeleton } from "./skeleton";
-import type { User } from "./test-data";
+import type { User } from "@/app/ui/user/card";
+import { useRouter } from "next/navigation";
 
-function truncateString(str: string, num: number): string {
+function truncateString(str: string | undefined, num: number): string {
+  if (!str) {
+    return "";
+  }
   if (str.length <= num) {
     return str;
   }
@@ -11,12 +17,17 @@ function truncateString(str: string, num: number): string {
 
 export function Sidebar({ users }: { users: User[] }) {
   // TODO: If users is empty, show a message like "No users found"
+  const router = useRouter();
+  const handleOnClick = (user: User) => {
+    router.push(`/chat/${user.id}`);
+  };
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4">
       <Stack spacing={2}>
         {users.map((user) => (
           <button
             key={user.id}
+            onClick={() => handleOnClick(user)}
             className="flex gap-2 items-center group hover:opacity-60"
           >
             <SmallAvatarSkeleton />

--- a/frontend/app/chat/test-data.ts
+++ b/frontend/app/chat/test-data.ts
@@ -1,9 +1,16 @@
-export type Message = {
+export type Chat = {
   id: number;
   user_id: number;
   user_name: string;
   text: string;
   created_at: string;
+};
+
+export type Message = {
+  to: string;
+  from: string;
+  userName: string;
+  content: string;
 };
 
 export type User = {
@@ -38,7 +45,7 @@ const users: User[] = [
   { id: 29410, name: "Sad Fox" },
 ];
 
-const messages: Message[] = [
+const messages: Chat[] = [
   {
     id: 1,
     user_id: 29387,

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -197,6 +197,7 @@ export async function getConversation(userOneId: string, userTwoId: string) {
     },
   );
   if (res.status === 404) {
+    console.error("Not found conversation: ", await res.json());
     return null;
   } else if (!res.ok) {
     console.error("getConversation error: ", await res.json());
@@ -218,7 +219,10 @@ export async function createConversation(userOneId: string, userTwoId: string) {
       userTwoId,
     }),
   });
-  if (!res.ok) {
+  if (res.status === 409) {
+    console.error("Already exists: ", await res.json());
+    return null;
+  } else if (!res.ok) {
     console.error("createConversation error: ", await res.json());
     throw new Error("createConversation error");
   } else {


### PR DESCRIPTION
[frontend]
- /chat/[id]/page.tsxを追加しました。
- メッセージ表示周りをロジックに合わせて調整しました。
- sidebarにcontext menuを追加しました。(右クリック or 2本指タップ)

現在dbに保存する際メッセージ本文と送信者のユーザー名しか保存していないので、type Messageのuser id(今の実装ではtype Messageのfrom)を使ったメッセージのグループ表示(同じユーザーが連投した時)はリロードすると無効になってしまう状態です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced chat functionality with improved user interaction and message grouping.
  - Introduced a new `TextInput` component for message input.
  - Implemented form validation for message sending.

- **Bug Fixes**
  - Fixed issues with user identification in message grouping.
  - Corrected the handling of user click events in the sidebar.

- **Refactor**
  - Streamlined chat page logic with parallel data retrieval and improved error handling.
  - Updated message data structure to include `to`, `from`, and `userName` fields.

- **Style**
  - Adjusted styles for the new search bar and chat components.

- **Documentation**
  - Updated documentation to reflect changes in chat functionality and message structure.

- **Chores**
  - Removed unused code and comments to clean up the codebase.

- **Tests**
  - Added tests for new chat functionalities and components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->