### PR TITLE
backend/direct message/block message

### DIFF
--- a/backend/prisma/migrations/20231209024519_add_is_blocked_to_dm_model/migration.sql
+++ b/backend/prisma/migrations/20231209024519_add_is_blocked_to_dm_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DirectMessage" ADD COLUMN     "isBlocked" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,4 +64,6 @@ model DirectMessage {
     receiver User @relation("ReceivedMessages", fields: [receiverId], references: [id])
 
     createdAt DateTime @default(now())
+
+    isBlocked Boolean @default(false)
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -39,6 +39,16 @@ export class ChatGateway {
   private logger: Logger = new Logger('ChatGateway');
 
   private userMap = new Map<string, string>();
+  private blockMap = new Map<number, number[]>();
+
+  private getValueToKey = (map, findValue) => {
+    for (const [key, value] of map.entries()) {
+      if (value == findValue) {
+        return key;
+      }
+    }
+    return '';
+  };
 
   @SubscribeMessage('newMessage')
   chatMessageToRoom(
@@ -63,15 +73,16 @@ export class ChatGateway {
   ): void {
     this.logger.log('private message received');
     this.logger.log(data);
-    let userId;
-    for (const [key, value] of this.userMap.entries()) {
-      if (value == client.id) {
-        userId = key;
-        break;
-      }
+
+    const userId = this.getValueToKey(this.userMap, client.id);
+    let isBlock = false;
+    if (this.blockMap.has(parseInt(userId))) {
+      const blockers = this.blockMap.get(parseInt(userId));
+      isBlock = blockers.includes(data.receiverId);
+      console.log(isBlock);
     }
     const userName = 'hoge'; //TODO mapを増やすか、mapのvalueを増やすか user name取得関数実装
-    this.chatService.createDirectMessage(+userId, data); //TODO userIdが見つからなかった場合どうする？
+    this.chatService.createDirectMessage(+userId, data, isBlock); //TODO userIdが見つからなかった場合どうする？
     this.server
       .except('block' + userId)
       .to(client.id)
@@ -84,8 +95,21 @@ export class ChatGateway {
     @MessageBody() userId: string,
     @ConnectedSocket() client: Socket,
   ) {
-    this.logger.log(`block user: ${userId}(${client.id})`);
-    client.join('block' + userId);
+    const blockerId = this.getValueToKey(this.userMap, client.id);
+    if (
+      this.blockMap.has(parseInt(userId)) &&
+      this.blockMap.get(parseInt(userId)).includes(parseInt(blockerId))
+    ) {
+      this.logger.error('Already blocked');
+    } else {
+      this.logger.log(`block user: ${userId}(${client.id})`);
+      if (this.blockMap.has(parseInt(userId))) {
+        this.blockMap.get(parseInt(userId)).push(parseInt(blockerId));
+      } else {
+        this.blockMap.set(parseInt(userId), [parseInt(blockerId)]);
+      }
+      client.join('block' + userId);
+    }
   }
 
   @SubscribeMessage('unblock')
@@ -93,6 +117,11 @@ export class ChatGateway {
     @MessageBody() userId: string,
     @ConnectedSocket() client: Socket,
   ) {
+    const unblockerId = this.getValueToKey(this.userMap, client.id);
+    if (this.blockMap.has(parseInt(userId))) {
+      const index = this.blockMap.get(parseInt(userId)).indexOf(unblockerId);
+      this.blockMap.get(parseInt(userId)).splice(index, 1);
+    }
     this.logger.log(`unblock user: ${userId}(${client.id})`);
     client.leave('block' + userId);
   }

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -3,10 +3,11 @@ import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { ChatGateway } from './chat.gateway';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { UserService } from '../user/user.service';
 
 @Module({
   controllers: [ChatController],
-  providers: [ChatGateway, ChatService],
+  providers: [ChatGateway, ChatService, UserService],
   imports: [PrismaModule],
 })
 export class ChatModule {}

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -7,10 +7,16 @@ import { User } from '@prisma/client';
 export class ChatService {
   constructor(private prisma: PrismaService) {}
 
-  async createDirectMessage(senderId: number, dto: CreateDirectMessageDto) {
+  async createDirectMessage(
+    senderId: number,
+    dto: CreateDirectMessageDto,
+    isBlocked: boolean,
+  ) {
+    console.log('isBlocked: ', isBlocked);
     return this.prisma.directMessage.create({
       data: {
         senderId,
+        isBlocked,
         ...dto, //TODO receiverIdのvalidationどうする？
       },
     });
@@ -29,6 +35,9 @@ export class ChatService {
           {
             receiverId: me.id,
             senderId: userId,
+            AND: {
+              isBlocked: false,
+            },
           },
         ],
       },


### PR DESCRIPTION
[backend]
- DirectMessage modelにisBlocked(Boolean)を追加しました。
- メッセージをDBに保存時にisBlockedの情報を追加して、GETでblock期間中に受信したメッセージは取得しないように変更しました。
- blockの有無は取り敢えずchat.gatewayの中でmapで持つようにしています。
- お試しでUserServiceのblock, unblock, findAllBlocked関数をchat.gatewayで使用してblock状態を永続化させています。

型の修正、リロード時のメッセージ表示形式の修正は別PRで行います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a message blocking feature in direct messaging, allowing users to block or unblock other users.

- **Enhancements**
  - Improved direct message creation to consider the blocking status between users.
  - Enhanced chat module to integrate user service for additional user-related functionalities.

- **Bug Fixes**
  - Fixed an issue where blocked messages could appear in direct message history. Messages from blocked users will no longer be displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->