### PR TITLE
Fix/backend/friend

### DIFF
--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -63,6 +63,7 @@ export class FriendRequestController {
   @Patch(':requesterId/accept')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiOkResponse()
   accept(
     @Param('userId', ParseIntPipe) userId: number,
     @Param('requesterId', ParseIntPipe) requesterId: number,
@@ -78,6 +79,7 @@ export class FriendRequestController {
   @Patch(':requesterId/reject')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiOkResponse()
   reject(
     @Param('userId', ParseIntPipe) userId: number,
     @Param('requesterId', ParseIntPipe) requesterId: number,
@@ -93,6 +95,7 @@ export class FriendRequestController {
   @Patch(':recipientId/cancel')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiOkResponse()
   cancel(
     @Param('userId', ParseIntPipe) userId: number,
     @Param('recipientId', ParseIntPipe) recipientId: number,

--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -23,15 +23,14 @@ import { UserEntity } from 'src/user/entities/user.entity';
 import { UserGuard } from 'src/user/user.guard';
 
 @Controller('user/:userId/friendrequest')
+@UseGuards(JwtAuthGuard, UserGuard)
+@ApiBearerAuth()
 @ApiTags('friendrequest')
 export class FriendRequestController {
   constructor(private readonly friendRequestService: FriendRequestService) {}
 
   // Send a friend request
   @Post()
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiCreatedResponse()
   create(
     @Body() createFriendRequestDto: CreateFriendRequestDto,
@@ -42,9 +41,6 @@ export class FriendRequestController {
 
   // Get all friend requests for a user
   @Get()
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOkResponse({ type: [UserEntity] })
   async findAll(@Req() req: { user: User }) {
     const users = await this.friendRequestService.findAll(req.user);
@@ -53,9 +49,6 @@ export class FriendRequestController {
 
   // Accept a friend request
   @Patch(':requesterId/accept')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOkResponse()
   accept(
     @Param('requesterId', ParseIntPipe) requesterId: number,
@@ -66,9 +59,6 @@ export class FriendRequestController {
 
   // Reject a friend request
   @Patch(':requesterId/reject')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOkResponse()
   reject(
     @Param('requesterId', ParseIntPipe) requesterId: number,
@@ -79,9 +69,6 @@ export class FriendRequestController {
 
   // Cancel a friend request
   @Patch(':recipientId/cancel')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOkResponse()
   cancel(
     @Param('recipientId', ParseIntPipe) recipientId: number,

--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -87,6 +87,6 @@ export class FriendRequestController {
     @Param('recipientId', ParseIntPipe) recipientId: number,
     @Req() req: { user: User },
   ) {
-    return this.friendRequestService.remove(recipientId, req.user);
+    return this.friendRequestService.cancel(recipientId, req.user);
   }
 }

--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   UseGuards,
   Req,
-  UnauthorizedException,
   ParseIntPipe,
 } from '@nestjs/common';
 import { FriendRequestService } from './friend-request.service';
@@ -21,6 +20,7 @@ import {
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { User } from '@prisma/client';
 import { UserEntity } from 'src/user/entities/user.entity';
+import { UserGuard } from 'src/user/user.guard';
 
 @Controller('user/:userId/friendrequest')
 @ApiTags('friendrequest')
@@ -29,81 +29,64 @@ export class FriendRequestController {
 
   // Send a friend request
   @Post()
+  @UseGuards(UserGuard)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiCreatedResponse()
   create(
-    @Param('userId', ParseIntPipe) userId: number,
     @Body() createFriendRequestDto: CreateFriendRequestDto,
     @Req() req: { user: User },
   ) {
-    if (req.user.id !== userId) {
-      throw new UnauthorizedException();
-    }
     return this.friendRequestService.create(createFriendRequestDto, req.user);
   }
 
   // Get all friend requests for a user
   @Get()
+  @UseGuards(UserGuard)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: [UserEntity] })
-  async findAll(
-    @Param('userId', ParseIntPipe) userId: number,
-    @Req() req: { user: User },
-  ) {
-    if (req.user.id !== userId) {
-      throw new UnauthorizedException();
-    }
+  async findAll(@Req() req: { user: User }) {
     const users = await this.friendRequestService.findAll(req.user);
     return users.map((user) => new UserEntity(user));
   }
 
   // Accept a friend request
   @Patch(':requesterId/accept')
+  @UseGuards(UserGuard)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   accept(
-    @Param('userId', ParseIntPipe) userId: number,
     @Param('requesterId', ParseIntPipe) requesterId: number,
     @Req() req: { user: User },
   ) {
-    if (req.user.id !== userId) {
-      throw new UnauthorizedException();
-    }
     return this.friendRequestService.accept(requesterId, req.user);
   }
 
   // Reject a friend request
   @Patch(':requesterId/reject')
+  @UseGuards(UserGuard)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   reject(
-    @Param('userId', ParseIntPipe) userId: number,
     @Param('requesterId', ParseIntPipe) requesterId: number,
     @Req() req: { user: User },
   ) {
-    if (req.user.id !== userId) {
-      throw new UnauthorizedException();
-    }
     return this.friendRequestService.reject(requesterId, req.user);
   }
 
   // Cancel a friend request
   @Patch(':recipientId/cancel')
+  @UseGuards(UserGuard)
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   cancel(
-    @Param('userId', ParseIntPipe) userId: number,
     @Param('recipientId', ParseIntPipe) recipientId: number,
     @Req() req: { user: User },
   ) {
-    if (req.user.id !== userId) {
-      throw new UnauthorizedException();
-    }
     return this.friendRequestService.remove(recipientId, req.user);
   }
 }

--- a/backend/src/friend-request/friend-request.service.ts
+++ b/backend/src/friend-request/friend-request.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
 import { User } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -27,39 +27,83 @@ export class FriendRequestService {
       .requestedBy();
   }
 
+  private async expectRequestedBy(requesterId: number, user: User, tx) {
+    const requests = await tx.user
+      .findFirstOrThrow({
+        where: { id: user.id },
+      })
+      .requestedBy({
+        where: { id: requesterId },
+      });
+    if (requests.length === 0) {
+      throw new NotFoundException('No friend request found');
+    }
+  }
+
+  private async expectRequesting(recipientId: number, user: User, tx) {
+    const requests = await tx.user
+      .findFirstOrThrow({
+        where: { id: user.id },
+      })
+      .requesting({
+        where: { id: recipientId },
+      });
+    if (requests.length === 0) {
+      throw new NotFoundException('No friend request found');
+    }
+  }
+
   accept(requesterId: number, user: User) {
-    return this.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        requestedBy: {
-          disconnect: { id: requesterId },
+    return this.prisma.$transaction(async (tx) => {
+      // Check if user is requested by requester
+      await this.expectRequestedBy(requesterId, user, tx);
+
+      // Remove the friend request and add the requester to friends
+      return tx.user.update({
+        where: { id: user.id },
+        data: {
+          requestedBy: {
+            disconnect: { id: requesterId },
+          },
+          friends: {
+            connect: { id: requesterId },
+          },
         },
-        friends: {
-          connect: { id: requesterId },
-        },
-      },
+      });
     });
   }
 
   reject(requesterId: number, user: User) {
-    return this.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        requestedBy: {
-          disconnect: { id: requesterId },
+    return this.prisma.$transaction(async (tx) => {
+      // Check if user is requested by requester
+      await this.expectRequestedBy(requesterId, user, tx);
+
+      // Remove the friend request
+      return tx.user.update({
+        where: { id: user.id },
+        data: {
+          requestedBy: {
+            disconnect: { id: requesterId },
+          },
         },
-      },
+      });
     });
   }
 
-  remove(recipientId: number, user: User) {
-    return this.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        requesting: {
-          disconnect: { id: recipientId },
+  cancel(recipientId: number, user: User) {
+    return this.prisma.$transaction(async (tx) => {
+      // Check if user is requesting recipient
+      await this.expectRequesting(recipientId, user, tx);
+
+      // Remove the friend request
+      return tx.user.update({
+        where: { id: user.id },
+        data: {
+          requesting: {
+            disconnect: { id: recipientId },
+          },
         },
-      },
+      });
     });
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -44,8 +44,7 @@ export class UserController {
   }
 
   @Get(':userId')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserEntity })
   async findOne(
@@ -55,8 +54,8 @@ export class UserController {
   }
 
   @Patch(':userId')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
+  @ApiBearerAuth()
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserEntity })
   async update(
@@ -68,8 +67,7 @@ export class UserController {
 
   @Delete(':userId')
   @HttpCode(204)
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
   async remove(@Param('userId', ParseIntPipe) userId: number): Promise<void> {
@@ -78,8 +76,7 @@ export class UserController {
 
   /* Friend requests */
   @Get(':userId/friend')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   async findAllFriends(@Param('userId', ParseIntPipe) userId: number) {
     const friends = await this.userService.findAllFriends(userId);
@@ -87,8 +84,7 @@ export class UserController {
   }
 
   @Get(':userId/block')
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   async findAllBlocked(@Param('userId', ParseIntPipe) userId: number) {
     const blocked = await this.userService.findAllBlocked(userId);
@@ -97,8 +93,7 @@ export class UserController {
 
   @Post(':userId/unfriend')
   @HttpCode(200)
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   removeFriend(
@@ -110,8 +105,7 @@ export class UserController {
 
   @Post(':userId/block')
   @HttpCode(200)
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   block(
@@ -123,8 +117,7 @@ export class UserController {
 
   @Post(':userId/unblock')
   @HttpCode(200)
-  @UseGuards(UserGuard)
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
   unblock(

--- a/backend/src/user/user.guard.ts
+++ b/backend/src/user/user.guard.ts
@@ -11,6 +11,9 @@ export class UserGuard implements CanActivate {
     if (!params?.userId) {
       throw new Error('UserGuard should only be used on routes with a userId');
     }
-    return user?.id === Number(params.userId);
+    if (typeof params.userId !== 'string' || !/^\d+$/.test(params.userId)) {
+      throw new Error('userId parameter must be a valid integer');
+    }
+    return user?.id === parseInt(params.userId, 10);
   }
 }

--- a/backend/src/user/user.guard.ts
+++ b/backend/src/user/user.guard.ts
@@ -1,4 +1,8 @@
-import { CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 
 export class UserGuard implements CanActivate {
@@ -12,7 +16,7 @@ export class UserGuard implements CanActivate {
       throw new Error('UserGuard should only be used on routes with a userId');
     }
     if (typeof params.userId !== 'string' || !/^\d+$/.test(params.userId)) {
-      throw new Error('userId parameter must be a valid integer');
+      throw new BadRequestException('userId parameter must be a valid integer');
     }
     return user?.id === parseInt(params.userId, 10);
   }

--- a/backend/test/user.e2e-spec.ts
+++ b/backend/test/user.e2e-spec.ts
@@ -558,4 +558,54 @@ describe('UserController (e2e)', () => {
       await getFriends(user2.id, user2.accessToken).expect(200).expect([]);
     });
   });
+
+  describe('Friend Request edge cases', () => {
+    let user1;
+    let user2;
+
+    beforeAll(async () => {
+      const setupUser = async (dto) => {
+        let res = await createUser(dto);
+        const user = res.body;
+        const loginDto: LoginDto = {
+          email: dto.email,
+          password: dto.password,
+        };
+        res = await login(loginDto);
+        user.accessToken = res.body.accessToken;
+        return user;
+      };
+      user1 = await setupUser(constants.user.test);
+      user2 = await setupUser(constants.user.test2);
+    });
+
+    afterAll(async () => {
+      const teardownUser = (user) => {
+        return deleteUser(user.id).set(
+          'Authorization',
+          `Bearer ${user.accessToken}`,
+        );
+      };
+      await teardownUser(user1);
+      await teardownUser(user2);
+    });
+
+    it('Should not accept requests that doesnt exist', async () => {
+      await acceptFriendRequest(user1.id, user2.id, user1.accessToken).expect(
+        404,
+      );
+    });
+
+    it('Should not reject requests that doesnt exist', async () => {
+      await rejectFriendRequest(user1.id, user2.id, user1.accessToken).expect(
+        404,
+      );
+    });
+
+    it('Should not cancel requests that doesnt exist', async () => {
+      await cancelFriendRequest(user1.id, user2.id, user1.accessToken).expect(
+        404,
+      );
+    });
+  });
 });

--- a/backend/test/user.e2e-spec.ts
+++ b/backend/test/user.e2e-spec.ts
@@ -103,7 +103,11 @@ describe('UserController (e2e)', () => {
       .send({ blockedUserId });
   };
 
-  const unblockUser = (userId: number, blockedUserId, accessToken: string) => {
+  const unblockUser = (
+    userId: number,
+    blockedUserId: number,
+    accessToken: string,
+  ) => {
     return request(app.getHttpServer())
       .post(`/user/${userId}/unblock`)
       .set('Authorization', `Bearer ${accessToken}`)


### PR DESCRIPTION
- BlockされてたらFriend Request送れない
- すでにFriendになってたらFriend Request送れない
- 自分自身にはFriend Request送れない
- Friend Requestが来ていないのにAccept/Rejectできない
- Friend Requestが送ってないのにCancelできない
などを実装しました。

また、上記の機能を並行処理でもレースコンディションにならないようにロックを取ったりするためにSQLのTransactionという仕組みを使っていますので、もし興味があれば調べてみてください。

## トランザクションの簡単な説明
```
1. Confirm B is not blocked by A
2. B send friend request to A
```
というのを普通に書くと、1と2の間にblockが行われた場合におかしなことになります。なので、1と2の間にデータベースに変更がないことを保証してくれる機能がtransactionです。

出来上がりとしては、こんな感じのイメージになります。
```
1. begin transaction
2. Confirm B is not blocked by A
3. B send friend request to A
4. commit transaction
```

（Prismaがtransactionを抽象化してくれてるので、使うときはこういう見た目とは少し違いますが。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced friend request functionality with improved validation and error handling.
  - Implemented transactional operations for friend request actions to ensure data integrity.

- **Bug Fixes**
  - Fixed issues where users could send friend requests to themselves or to users they are already friends with or have blocked.

- **Refactor**
  - Centralized authorization checks using `UserGuard` to streamline friend request operations.
  - Refactored friend request methods for better readability and maintainability.

- **Tests**
  - Added comprehensive end-to-end test cases for friend request edge cases.

- **Documentation**
  - Updated function parameters for clarity in test specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->