### PR TITLE
Fix/direct message/block

### DIFF
--- a/backend/prisma/migrations/20231209144011_remove_is_blocked_from_dm_model/migration.sql
+++ b/backend/prisma/migrations/20231209144011_remove_is_blocked_from_dm_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isBlocked` on the `DirectMessage` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "DirectMessage" DROP COLUMN "isBlocked";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,6 +64,4 @@ model DirectMessage {
     receiver User @relation("ReceivedMessages", fields: [receiverId], references: [id])
 
     createdAt DateTime @default(now())
-
-    isBlocked Boolean @default(false)
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -79,14 +79,8 @@ export class ChatGateway {
     this.logger.log(data);
 
     const userId = this.getValueToKey(this.userMap, client.id);
-    let isBlock = false;
-    if (this.blockMap.has(parseInt(userId))) {
-      const blockers = this.blockMap.get(parseInt(userId));
-      isBlock = blockers.includes(data.receiverId);
-      console.log(isBlock);
-    }
     const userName = 'hoge'; //TODO mapを増やすか、mapのvalueを増やすか user name取得関数実装
-    this.chatService.createDirectMessage(+userId, data, isBlock); //TODO userIdが見つからなかった場合どうする？
+    this.chatService.createDirectMessage(+userId, data); //TODO userIdが見つからなかった場合どうする？
     this.server
       .except('block' + userId)
       .to(client.id)
@@ -125,7 +119,9 @@ export class ChatGateway {
     const unblockerId = this.getValueToKey(this.userMap, client.id);
     if (this.blockMap.has(parseInt(userId))) {
       this.userService.unblock(parseInt(unblockerId), parseInt(userId));
-      const index = this.blockMap.get(parseInt(userId)).indexOf(unblockerId);
+      const index = this.blockMap
+        .get(parseInt(userId))
+        .indexOf(parseInt(unblockerId));
       if (index !== -1) {
         this.blockMap.get(parseInt(userId)).splice(index, 1);
         this.logger.log(`unblock user: ${userId}(${client.id})`);
@@ -133,6 +129,8 @@ export class ChatGateway {
       } else {
         this.logger.error(`User ${userId} has not been blocked`);
       }
+    } else {
+      this.logger.error(`User ${userId} has not been blocked`);
     }
   }
 
@@ -145,7 +143,6 @@ export class ChatGateway {
     const blockedUsers = await this.userService.findAllBlocked(
       parseInt(userId),
     );
-    console.log('block list', blockedUsers);
     blockedUsers.map((user) => client.join('block' + user.id));
     this.logger.log(`join DM: ${client.id} joined DM user${userId}`);
   }

--- a/frontend/app/chat/helper.ts
+++ b/frontend/app/chat/helper.ts
@@ -7,7 +7,8 @@ export function groupMessagesByUser(messages: Message[]): Message[][] {
   let currentGroup: Message[] = [];
 
   for (const msg of messages) {
-    if (parseInt(msg.from) === prevUserId) {
+    console.log("from", msg.receiverId);
+    if (msg.receiverId === prevUserId) {
       currentGroup.push(msg);
     } else {
       if (currentGroup.length) {
@@ -15,7 +16,7 @@ export function groupMessagesByUser(messages: Message[]): Message[][] {
       }
       currentGroup = [msg];
     }
-    prevUserId = parseInt(msg.from);
+    prevUserId = msg.receiverId;
   }
 
   if (currentGroup.length) {

--- a/frontend/app/chat/message-area.tsx
+++ b/frontend/app/chat/message-area.tsx
@@ -53,7 +53,7 @@ function MessageArea({ me, other }: { me: User; other: User }) {
   const messageGroups = groupMessagesByUser(messages);
   const contentRef: React.RefObject<HTMLDivElement> = useRef(null);
   const isScrolledToBottom = useScrollToBottom(contentRef, messages);
-  const myId = me.id.toString();
+  const myId = me.id;
   const otherId = other.id;
 
   // TODO: Messageを取得するsocketのロジック等を実装
@@ -63,7 +63,7 @@ function MessageArea({ me, other }: { me: User; other: User }) {
     socket.emit("joinDM", myId);
 
     const handleMessageReceived = (newMessage: Message) => {
-      if (newMessage.from === otherId.toString() || newMessage.from === myId) {
+      if (newMessage.receiverId === otherId || newMessage.receiverId === myId) {
         console.log("received message: ", newMessage);
         setMessages((oldMessages) => [...oldMessages, newMessage]);
         console.log(newMessage);

--- a/frontend/app/chat/message-area.tsx
+++ b/frontend/app/chat/message-area.tsx
@@ -17,6 +17,9 @@ async function getMessages(otherId: number) {
   console.log("conversation: ");
   // TODO: Implement this function
   let conversation = await getConversation(otherId);
+  if (!conversation) {
+    conversation = [];
+  }
   console.log("conversation: ", conversation);
   return conversation;
 }

--- a/frontend/app/chat/test-data.ts
+++ b/frontend/app/chat/test-data.ts
@@ -7,8 +7,8 @@ export type Chat = {
 };
 
 export type Message = {
-  to: string;
-  from: string;
+  senderId: number;
+  receiverId: number;
   userName: string;
   content: string;
 };

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -199,9 +199,12 @@ export async function getConversation(userId: number) {
   if (res.status === 404) {
     console.error("Not found conversation: ", await res.json());
     return null;
+  } else if (res.status === 409) {
+    console.error("Conflict conversation: ", await res.json());
+    return null;
   } else if (!res.ok) {
     console.error("getConversation error: ", await res.json());
-    throw new Error("createConversation error");
+    throw new Error("getConversation error");
   } else {
     const conversation = await res.json();
     return conversation;


### PR DESCRIPTION
[backend]
- DM modelからisBlockedを削除しました。
- modelの変更に合わせてchat.serviceとchat.gatewayを修正しました。
- findConversation関数内でexpectNotBlockedBy関数を使用してblock時にはconflict errorをthrowするように変更しました。

[frontend]
- backendの変更で出たエラーに合わせて修正しました。

[frontend/backend]
- 型を修正しました。

block時にリロードするとメッセージが全て非表示になり、unblock時は全て表示されるようになっています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat functionality now includes user blocking capabilities.
  - Messages are now grouped by receiver ID for improved clarity.

- **Bug Fixes**
  - Fixed an issue where messages could be sent to blocked users.
  - Resolved a problem where the conversation array was not initialized correctly.

- **Refactor**
  - Streamlined the process of creating direct messages by removing redundant block checks.
  - Enhanced error logging for unblocking actions and joining direct message channels.

- **Style**
  - Removed unnecessary console logs for a cleaner codebase.

- **Documentation**
  - Updated message type definitions to reflect new `senderId` and `receiverId` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->