### PR TITLE
Feat/backend/room/add role guard

### DIFF
--- a/backend/src/room/roles.decorators.ts
+++ b/backend/src/room/roles.decorators.ts
@@ -1,4 +1,0 @@
-import { Reflector } from '@nestjs/core';
-import { Role } from '@prisma/client';
-
-export const roleNeed = Reflector.createDecorator<Role>();

--- a/backend/src/room/roles.decorators.ts
+++ b/backend/src/room/roles.decorators.ts
@@ -1,0 +1,4 @@
+import { Reflector } from '@nestjs/core';
+import { Role } from '@prisma/client';
+
+export const roleNeed = Reflector.createDecorator<Role>();

--- a/backend/src/room/room-member.guard.ts
+++ b/backend/src/room/room-member.guard.ts
@@ -1,7 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { Reflector } from '@nestjs/core';
-import { roleNeed } from './roles.decorators';
 import { RoomService } from './room.service';
 import { Role } from '@prisma/client';
 
@@ -20,16 +19,14 @@ export class RoomRolesGuard implements CanActivate {
   canActivate(
     context: ExecutionContext,
   ): Promise<boolean> | boolean | Observable<boolean> {
-    const need = this.reflector.get(roleNeed, context.getHandler());
-    if (!need) {
-      // roleNeed decorator not found
-      return true;
-    }
     const request = context.switchToHttp().getRequest();
     const user = request['user'];
     const roomId = request.params.id;
     return this.getUserRole(user, roomId)
-      .then((userRole) => this.matchRole(need, userRole))
+      .then((userRole) => {
+        request['userRole'] = userRole;
+        return true;
+      })
       .catch(() => {
         return false;
       });

--- a/backend/src/room/room-member.guard.ts
+++ b/backend/src/room/room-member.guard.ts
@@ -1,13 +1,64 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Observable } from 'rxjs';
+import { Reflector } from '@nestjs/core';
+import { roleNeed } from './roles.decorators';
+import { RoomService } from './room.service';
+import { Role } from '@prisma/client';
+
+interface User {
+  id: number;
+  name: string;
+}
 
 @Injectable()
 export class RoomRolesGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private roomService: RoomService,
+  ) {}
+
   canActivate(
     context: ExecutionContext,
   ): Promise<boolean> | boolean | Observable<boolean> {
-    console.log('needRole : ');
+    const need = this.reflector.get(roleNeed, context.getHandler());
+    if (!need) {
+      // roleNeed decorator not found
+      return true;
+    }
     const request = context.switchToHttp().getRequest();
-    return true;
+    const user = request['user'];
+    const roomId = request.params.id;
+    return this.getUserRole(user, roomId)
+      .then((userRole) => this.matchRole(need, userRole))
+      .catch(() => {
+        return false;
+      });
+  }
+  private matchRole(need: Role, userRole: Role): boolean {
+    return userRole !== undefined
+      ? this.meetRequirement(need, userRole)
+      : false;
+  }
+
+  private getUserRole(user: User, roomId: string): Promise<Role> {
+    return this.roomService
+      .findUserOnRoom(Number(roomId), user, user.id)
+      .then((userOnRoomEntity) => userOnRoomEntity.role)
+      .catch(() => Promise.reject());
+  }
+
+  private meetRequirement(need: Role, userRole: Role): boolean {
+    return this.roleToNum(userRole) >= this.roleToNum(need);
+  }
+
+  private roleToNum(role: Role): number {
+    switch (role) {
+      case Role.MEMBER:
+        return 0;
+      case Role.ADMINISTRATOR:
+        return 1;
+      case Role.OWNER:
+        return 2;
+    }
   }
 }

--- a/backend/src/room/room-member.guard.ts
+++ b/backend/src/room/room-member.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class RoomRolesGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): Promise<boolean> | boolean | Observable<boolean> {
+    console.log('needRole : ');
+    const request = context.switchToHttp().getRequest();
+    return true;
+  }
+}

--- a/backend/src/room/room-member.guard.ts
+++ b/backend/src/room/room-member.guard.ts
@@ -31,15 +31,10 @@ export class RoomRolesGuard implements CanActivate {
         return false;
       });
   }
-  private matchRole(need: Role, userRole: Role): boolean {
-    return userRole !== undefined
-      ? this.meetRequirement(need, userRole)
-      : false;
-  }
 
   private getUserRole(user: User, roomId: string): Promise<Role> {
     return this.roomService
-      .findUserOnRoom(Number(roomId), user, user.id)
+      .findUserOnRoom(Number(roomId), user.id)
       .then((userOnRoomEntity) => userOnRoomEntity.role)
       .catch(() => Promise.reject());
   }

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -49,8 +49,8 @@ export class RoomController {
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
-  findOne(@Param('id', ParseIntPipe) id: number, @Req() request: Request) {
-    return this.roomService.findRoom(id, request['user']);
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.findRoom(id);
   }
 
   @Patch(':id')
@@ -62,7 +62,7 @@ export class RoomController {
     @Body() updateRoomDto: UpdateRoomDto,
     @Req() request: Request,
   ) {
-    return this.roomService.updateRoom(id, updateRoomDto, request['user']);
+    return this.roomService.updateRoom(id, updateRoomDto, request['userRole']);
   }
 
   @Delete(':id')
@@ -70,11 +70,8 @@ export class RoomController {
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
-  async removeRoom(
-    @Param('id', ParseIntPipe) id: number,
-    @Req() request: Request,
-  ) {
-    await this.roomService.removeRoom(id, request['user']);
+  removeRoom(@Param('id', ParseIntPipe) id: number, @Req() request: Request) {
+    return this.roomService.removeRoom(id, request['userRole']);
   }
 
   @Post(':id')
@@ -95,9 +92,8 @@ export class RoomController {
   getUserOnRoom(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
-    @Req() request: Request,
   ) {
-    return this.roomService.findUserOnRoom(id, request['user'], userId);
+    return this.roomService.findUserOnRoom(id, userId);
   }
 
   @Delete(':id/:userId')
@@ -108,11 +104,13 @@ export class RoomController {
   async deleteUserOnRoom(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
+    @Req() request: Request,
   ) {
     await this.roomService.removeUserOnRoom(
       id,
-      { id: userId, name: 'test' },
+      request['userRole'],
       userId,
+      request['user'],
     );
   }
 
@@ -128,7 +126,7 @@ export class RoomController {
   ) {
     return this.roomService.updateUserOnRoom(
       id,
-      request['user'],
+      request['userRole'],
       userId,
       updateUserOnRoomDto,
     );

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -26,8 +26,6 @@ import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
 import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { RoomRolesGuard } from './room-member.guard';
-import { roleNeed } from './roles.decorators';
-import { Role } from '@prisma/client';
 
 @Controller('room')
 @ApiTags('room')
@@ -48,7 +46,7 @@ export class RoomController {
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
   findOne(@Param('id', ParseIntPipe) id: number, @Req() request: Request) {
@@ -56,7 +54,6 @@ export class RoomController {
   }
 
   @Patch(':id')
-  @roleNeed(Role.OWNER)
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
@@ -70,7 +67,6 @@ export class RoomController {
 
   @Delete(':id')
   @HttpCode(204)
-  @roleNeed(Role.OWNER)
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
@@ -93,7 +89,6 @@ export class RoomController {
   }
 
   @Get(':id/:userId')
-  @roleNeed(Role.MEMBER)
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
@@ -107,7 +102,6 @@ export class RoomController {
 
   @Delete(':id/:userId')
   @HttpCode(204)
-  @roleNeed(Role.MEMBER)
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
@@ -123,7 +117,6 @@ export class RoomController {
   }
 
   @Patch(':id/:userId')
-  @roleNeed(Role.MEMBER)
   @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -26,6 +26,8 @@ import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
 import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { RoomRolesGuard } from './room-member.guard';
+import { roleNeed } from './roles.decorators';
+import { Role } from '@prisma/client';
 
 @Controller('room')
 @ApiTags('room')
@@ -54,7 +56,8 @@ export class RoomController {
   }
 
   @Patch(':id')
-  @UseGuards(JwtAuthGuard)
+  @roleNeed(Role.OWNER)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
   update(
@@ -67,7 +70,8 @@ export class RoomController {
 
   @Delete(':id')
   @HttpCode(204)
-  @UseGuards(JwtAuthGuard)
+  @roleNeed(Role.OWNER)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
   async removeRoom(
@@ -89,8 +93,8 @@ export class RoomController {
   }
 
   @Get(':id/:userId')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(RoomRolesGuard)
+  @roleNeed(Role.MEMBER)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   getUserOnRoom(
@@ -103,7 +107,8 @@ export class RoomController {
 
   @Delete(':id/:userId')
   @HttpCode(204)
-  @UseGuards(JwtAuthGuard)
+  @roleNeed(Role.MEMBER)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
   async deleteUserOnRoom(
@@ -118,7 +123,8 @@ export class RoomController {
   }
 
   @Patch(':id/:userId')
-  @UseGuards(JwtAuthGuard)
+  @roleNeed(Role.MEMBER)
+  @UseGuards(JwtAuthGuard, RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   updateUserOnRoom(

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -25,6 +25,7 @@ import { RoomEntity } from './entities/room.entity';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
 import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
+import { RoomRolesGuard } from './room-member.guard';
 
 @Controller('room')
 @ApiTags('room')
@@ -89,6 +90,7 @@ export class RoomController {
 
   @Get(':id/:userId')
   @UseGuards(JwtAuthGuard)
+  @UseGuards(RoomRolesGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   getUserOnRoom(


### PR DESCRIPTION
## RoleGuard decorator を追加した

該当するAPIになんのRoleを必要とするかを controller のdecorator で解決する案もあったが、
認可ロジックがコントローラーに入ってしまうのでやめた

RoleGuard 内で、jwtguard と同様に、user のRoleを request['userRole']に追加することで、service 内でそれを確認しやすいようにしています。

## 変なところ
- 何かRole が必要なAPIは大体同権限のメンバーをいじれるようになっていまる
( admin が他の admin を member に降格することができる )
- owner は owner を作成することができてしまう
-> ロジックで防ぐこともできるが、モデル定義で解決できたら嬉しい。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented role-based access control for room-related actions.

- **Enhancements**
  - Streamlined room and user management by removing unnecessary parameters and simplifying method signatures.

- **Bug Fixes**
  - Adjusted user role checks to ensure proper permissions are enforced when updating or removing rooms and users.

- **Tests**
  - Added new end-to-end tests for role-based actions such as kicking users from rooms and updating user roles.
  - Updated existing tests to align with the new role-based access control logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->