### PR TITLE
chat roomページでadminの付与とkickをできるように実装

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -190,19 +190,30 @@ export class ChatGateway {
   }
 
   @SubscribeMessage('updateRole')
-  handleUpdataRole(
+  handleUpdateRole(
     @MessageBody()
     { roomId, userId, role }: { roomId: number; userId: number; role: string },
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.log(`update role user: ${userId} room ${roomId} role ${role}`);
+    if (role !== 'ADMINISTRATOR' && role !== 'MEMBER') {
+      this.logger.error('invalid role');
+      return;
+    }
     if (client.rooms.has('room/' + roomId)) {
       this.server
-        .to(this.userMap.get(userId))
-        .emit('updateRole', role, client.id);
+        .to('room/' + roomId)
+        .emit('updateRole', role, userId, client.id);
     } else {
       this.logger.error('socket has not joined this room');
     }
+    //    if (client.rooms.has('room/' + roomId)) {
+    //      this.server
+    //        .to(this.userMap.get(userId))
+    //        .emit('updateRole', role, client.id);
+    //    } else {
+    //      this.logger.error('socket has not joined this room');
+    //    }
   }
 
   handleConnection(@ConnectedSocket() client: Socket) {

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -176,6 +176,35 @@ export class ChatGateway {
     client.leave('room/' + roomId);
   }
 
+  @SubscribeMessage('kick')
+  handleKick(
+    @MessageBody() { roomId, userId }: { roomId: number; userId: number },
+    @ConnectedSocket() client: Socket,
+  ) {
+    this.logger.log(`kick user: ${userId} left room ${roomId}`);
+    if (client.rooms.has('room/' + roomId)) {
+      this.server.to('room/' + roomId).emit('kick', userId, client.id);
+    } else {
+      this.logger.error('socket has not joined this room');
+    }
+  }
+
+  @SubscribeMessage('updateRole')
+  handleUpdataRole(
+    @MessageBody()
+    { roomId, userId, role }: { roomId: number; userId: number; role: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    this.logger.log(`update role user: ${userId} room ${roomId} role ${role}`);
+    if (client.rooms.has('room/' + roomId)) {
+      this.server
+        .to(this.userMap.get(userId))
+        .emit('updateRole', role, client.id);
+    } else {
+      this.logger.error('socket has not joined this room');
+    }
+  }
+
   handleConnection(@ConnectedSocket() client: Socket) {
     this.logger.log(`Client connected: ${client.id}`);
   }

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -210,3 +210,42 @@ export async function getConversation(userId: number) {
     return conversation;
   }
 }
+
+export async function updateRoomUser(
+  role: string,
+  roomId: number,
+  userId: number,
+) {
+  const res = await fetch(`${process.env.API_URL}/room/${roomId}/${userId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + getAccessToken(),
+    },
+    body: JSON.stringify({ role }),
+  });
+  console.log(res.status);
+  if (!res.ok) {
+    console.error("updateRoomUser error: ", await res.json());
+    throw new Error("updateRoomUser error");
+  } else {
+    const update = await res.json();
+    console.log(update);
+    return "Success";
+  }
+}
+
+export async function deleteRoomUser(roomId: number, userId: number) {
+  const res = await fetch(`${process.env.API_URL}/room/${roomId}/${userId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: "Bearer " + getAccessToken(),
+    },
+  });
+  if (!res.ok) {
+    console.error("deleteRoomUser error: ", await res.json());
+    throw new Error("deleteRoomUser error");
+  } else {
+    return "Success";
+  }
+}

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -25,20 +25,18 @@
 //  );
 //}
 
-import ChatRoomCard from "@/app/ui/room/chat-room";
 import { getUserId } from "@/app/lib/session";
-import { getRoom, getUser, getUsers } from "@/app/lib/actions";
-import { notFound } from "next/navigation";
 import { Separator } from "@/components/ui/separator";
-import { Sidebar } from "@/app/chat/sidebar";
+import { Sidebar } from "../sidebar";
+import { getRoom, getUsers, getUser } from "@/app/lib/actions";
 import MessageArea from "../message-area";
+import { notFound } from "next/navigation";
 import type { User } from "@/app/ui/user/card";
+import type { UserOnRoom, UserWithRole } from "../sidebar";
 
-type UserOnRoom = {
+type UserRole = {
   id: number;
-  userId: number;
   role: string;
-  roomId: number;
 };
 
 export default async function Page({
@@ -46,25 +44,43 @@ export default async function Page({
 }: {
   params: { id: number };
 }) {
-  const roomInfo = await getRoom(id);
-  if (!roomInfo) {
-    notFound();
-  }
-  const userOnRoom = roomInfo.users.map((user: UserOnRoom) => user.userId);
   const currentUserId = await getUserId();
   if (!currentUserId) {
     console.error("getUserId error");
     throw new Error("getUserId error");
   }
+  const roomInfo = await getRoom(id);
+  if (!roomInfo) {
+    notFound();
+  }
+  const userOnRoom = roomInfo.users.map((user: UserOnRoom) => user.userId);
+  console.log("userOnRoom", userOnRoom);
+  const usersRole = roomInfo.users
+    .map((user: UserOnRoom) => ({ id: user.userId, role: user.role }))
+    .sort((a: UserRole, b: UserRole) => a.id - b.id);
+
+  const myInfo = roomInfo.users.find((user: UserOnRoom) => {
+    return user.userId === parseInt(currentUserId);
+  });
+  if (!myInfo) {
+    console.error("Not participating in room");
+    throw new Error("Not participating in room");
+  }
   const allUsers = await getUsers();
   const participate = allUsers.filter((user) => {
     return userOnRoom.includes(user.id);
   });
+  const participateWithRole: UserWithRole<User>[] = participate.map(
+    (user, i) => ({
+      ...user,
+      role: usersRole[i].role,
+    }),
+  );
   const currentUser = await getUser(parseInt(currentUserId));
   return (
     <>
       <div className="overflow-auto flex-grow flex gap-4 pb-4">
-        <Sidebar users={participate} />
+        <Sidebar roomId={id} myInfo={myInfo} users={participateWithRole} />
         <Separator orientation="vertical" />
         <MessageArea roomId={id} me={currentUser} />
       </div>

--- a/frontend/app/room/sidebar-button.tsx
+++ b/frontend/app/room/sidebar-button.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { SmallAvatarSkeleton } from "@/app/chat/skeleton";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Stack } from "@/app/ui/layout/stack";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { chatSocket as socket } from "@/socket";
+import type { User } from "@/app/ui/user/card";
+import { updateRoomUser, deleteRoomUser } from "@/app/lib/actions";
+import type { UserOnRoom, UserWithRole } from "./sidebar";
+
+function truncateString(str: string | undefined, num: number): string {
+  if (!str) {
+    return "";
+  }
+  if (str.length <= num) {
+    return str;
+  }
+  return str.slice(0, num) + "...";
+}
+
+export function SidebarButton({
+  roomId,
+  user,
+  myInfo,
+}: {
+  roomId: number;
+  user: UserWithRole<User>;
+  myInfo: UserOnRoom;
+}) {
+  console.log("role", user.role);
+  const router = useRouter();
+  const [isBlocked, setIsBlocked] = useState(false);
+  const [isChecked, setChecked] = useState(
+    user.role === "OWNER" || user.role === "ADMINISTRATOR",
+  );
+  const isMeOwner = myInfo.role === "OWNER";
+  const isMeAdmin = myInfo.role === "OWNER" || myInfo.role === "ADMINISTRATOR";
+  const isOwner = user.role === "OWNER";
+  let isAdmin = user.role === "OWNER" || user.role === "ADMINISTRATOR";
+
+  const handleOnClick = () => {
+    router.push(`/room/${roomId}`);
+  };
+
+  const blockUser = (user: User) => {
+    socket.emit("block", user.id);
+    setIsBlocked(true);
+  };
+
+  const unblockUser = (user: User) => {
+    socket.emit("unblock", user.id);
+    setIsBlocked(false);
+  };
+
+  const kickUser = (roomId: number, user: User) => {
+    deleteRoomUser(roomId, user.id);
+    socket.emit("kick", user.id);
+  };
+
+  const handleCheckboxChange = (roomId: number, user: User) => {
+    if (!isChecked) {
+      updateRoomUser("ADMINISTRATOR", roomId, user.id);
+      setChecked(true);
+    } else {
+      updateRoomUser("MEMBER", roomId, user.id);
+      setChecked(false);
+    }
+  };
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <button
+            onClick={() => handleOnClick()}
+            className="flex gap-2 items-center group hover:opacity-60"
+          >
+            <SmallAvatarSkeleton />
+            <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
+              {truncateString(user.name, 15)}
+            </span>
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-56">
+          <ContextMenuItem inset>Go profile</ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem inset disabled={isBlocked}>
+            <button onClick={() => blockUser(user)}>Block</button>
+          </ContextMenuItem>
+          <ContextMenuItem inset disabled={!isBlocked}>
+            <button onClick={() => unblockUser(user)}>Unblock</button>
+          </ContextMenuItem>
+          {isMeAdmin && myInfo.userId !== user.id && (
+            <ContextMenuItem inset disabled={isOwner}>
+              <button onClick={() => kickUser(roomId, user)}>Kick</button>
+            </ContextMenuItem>
+          )}
+          {isMeOwner && myInfo.userId !== user.id && (
+            <ContextMenuItem inset disabled={isOwner}>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="terms"
+                  checked={isChecked}
+                  onCheckedChange={() => handleCheckboxChange(roomId, user)}
+                />
+                <label
+                  htmlFor="terms"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  admin
+                </label>
+              </div>
+            </ContextMenuItem>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+    </>
+  );
+}

--- a/frontend/app/room/sidebar-button.tsx
+++ b/frontend/app/room/sidebar-button.tsx
@@ -11,11 +11,12 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Stack } from "@/app/ui/layout/stack";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { chatSocket as socket } from "@/socket";
 import type { User } from "@/app/ui/user/card";
-import { updateRoomUser, deleteRoomUser } from "@/app/lib/actions";
 import type { UserOnRoom, UserWithRole } from "./sidebar";
+import { updateRoomUser, deleteRoomUser } from "@/app/lib/actions";
+import { redirect, RedirectType } from "next/navigation";
 
 function truncateString(str: string | undefined, num: number): string {
   if (!str) {
@@ -42,8 +43,9 @@ export function SidebarButton({
   const [isChecked, setChecked] = useState(
     user.role === "OWNER" || user.role === "ADMINISTRATOR",
   );
-  const isMeOwner = myInfo.role === "OWNER";
-  const isMeAdmin = myInfo.role === "OWNER" || myInfo.role === "ADMINISTRATOR";
+  const [myRole, setMyRole] = useState(myInfo.role);
+  const isMeOwner = myRole === "OWNER";
+  const isMeAdmin = myRole === "OWNER" || myRole === "ADMINISTRATOR";
   const isOwner = user.role === "OWNER";
   let isAdmin = user.role === "OWNER" || user.role === "ADMINISTRATOR";
 
@@ -63,18 +65,48 @@ export function SidebarButton({
 
   const kickUser = (roomId: number, user: User) => {
     deleteRoomUser(roomId, user.id);
-    socket.emit("kick", user.id);
+    socket.emit("kick", { roomId, userId: user.id });
   };
 
   const handleCheckboxChange = (roomId: number, user: User) => {
     if (!isChecked) {
       updateRoomUser("ADMINISTRATOR", roomId, user.id);
+      socket.emit("updateRole", {
+        roomId,
+        userId: user.id,
+        role: "ADMINISTRATOR",
+      });
       setChecked(true);
     } else {
       updateRoomUser("MEMBER", roomId, user.id);
+      socket.emit("updateRole", { roomId, userId: user.id, role: "MEMBER" });
       setChecked(false);
     }
   };
+
+  useEffect(() => {
+    const handleKick = (kickId: number) => {
+      if (kickId === myInfo.userId) {
+        router.push("/room");
+      }
+    };
+
+    const handleUpdateRole = (role: string) => {
+      if (role === "MEMBER" || role === "ADMINISTRATOR") {
+        console.log("role", role);
+        setMyRole(role);
+      } else {
+        console.error("invalid role");
+      }
+    };
+    socket.on("kick", handleKick);
+    socket.on("updateRole", handleUpdateRole);
+
+    return () => {
+      socket.off("kick", handleKick);
+      socket.off("updateRole", handleUpdateRole);
+    };
+  }, [myInfo.userId, router]);
 
   return (
     <>
@@ -87,24 +119,33 @@ export function SidebarButton({
             <SmallAvatarSkeleton />
             <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
               {truncateString(user.name, 15)}
+              {user.role === "OWNER" && "👑"}
+              {user.role === "ADMINISTRATOR" && "🛡"}
             </span>
           </button>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-56">
           <ContextMenuItem inset>Go profile</ContextMenuItem>
           <ContextMenuSeparator />
-          <ContextMenuItem inset disabled={isBlocked}>
+          <ContextMenuItem
+            inset
+            disabled={isBlocked || myInfo.userId === user.id}
+          >
             <button onClick={() => blockUser(user)}>Block</button>
           </ContextMenuItem>
-          <ContextMenuItem inset disabled={!isBlocked}>
+          <ContextMenuItem
+            inset
+            disabled={!isBlocked || myInfo.userId === user.id}
+          >
             <button onClick={() => unblockUser(user)}>Unblock</button>
           </ContextMenuItem>
-          {isMeAdmin && myInfo.userId !== user.id && (
-            <ContextMenuItem inset disabled={isOwner}>
-              <button onClick={() => kickUser(roomId, user)}>Kick</button>
-            </ContextMenuItem>
-          )}
-          {isMeOwner && myInfo.userId !== user.id && (
+          {(myRole === "ADMINISTRATOR" || myRole === "OWNER") &&
+            myInfo.userId !== user.id && (
+              <ContextMenuItem inset disabled={isOwner}>
+                <button onClick={() => kickUser(roomId, user)}>Kick</button>
+              </ContextMenuItem>
+            )}
+          {myRole === "OWNER" && myInfo.userId !== user.id && (
             <ContextMenuItem inset disabled={isOwner}>
               <div className="flex items-center space-x-2">
                 <Checkbox

--- a/frontend/app/room/sidebar-button.tsx
+++ b/frontend/app/room/sidebar-button.tsx
@@ -82,12 +82,6 @@ export function SidebarButton({
   };
 
   useEffect(() => {
-    const handleKick = (kickId: number) => {
-      if (kickId === myInfo.userId) {
-        router.push("/room");
-      }
-    };
-
     const handleUpdateRole = (role: string, userId: number) => {
       if (role === "MEMBER" || role === "ADMINISTRATOR") {
         console.log("role", role);
@@ -101,14 +95,12 @@ export function SidebarButton({
         console.error("invalid role");
       }
     };
-    socket.on("kick", handleKick);
     socket.on("updateRole", handleUpdateRole);
 
     return () => {
-      socket.off("kick", handleKick);
       socket.off("updateRole", handleUpdateRole);
     };
-  }, [myInfo.userId, user.id, router]);
+  }, [myInfo.userId, user.id]);
 
   return (
     <>

--- a/frontend/app/room/sidebar-button.tsx
+++ b/frontend/app/room/sidebar-button.tsx
@@ -44,10 +44,7 @@ export function SidebarButton({
     user.role === "OWNER" || user.role === "ADMINISTRATOR",
   );
   const [myRole, setMyRole] = useState(myInfo.role);
-  const isMeOwner = myRole === "OWNER";
-  const isMeAdmin = myRole === "OWNER" || myRole === "ADMINISTRATOR";
-  const isOwner = user.role === "OWNER";
-  let isAdmin = user.role === "OWNER" || user.role === "ADMINISTRATOR";
+  const [userRole, setUserRole] = useState(user.role);
 
   const handleOnClick = () => {
     router.push(`/room/${roomId}`);
@@ -91,10 +88,15 @@ export function SidebarButton({
       }
     };
 
-    const handleUpdateRole = (role: string) => {
+    const handleUpdateRole = (role: string, userId: number) => {
       if (role === "MEMBER" || role === "ADMINISTRATOR") {
         console.log("role", role);
-        setMyRole(role);
+        if (userId === myInfo.userId) {
+          setMyRole(role);
+        }
+        if (userId === user.id) {
+          setUserRole(role);
+        }
       } else {
         console.error("invalid role");
       }
@@ -106,7 +108,7 @@ export function SidebarButton({
       socket.off("kick", handleKick);
       socket.off("updateRole", handleUpdateRole);
     };
-  }, [myInfo.userId, router]);
+  }, [myInfo.userId, user.id, router]);
 
   return (
     <>
@@ -119,8 +121,8 @@ export function SidebarButton({
             <SmallAvatarSkeleton />
             <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
               {truncateString(user.name, 15)}
-              {user.role === "OWNER" && "👑"}
-              {user.role === "ADMINISTRATOR" && "🛡"}
+              {userRole === "OWNER" && "👑"}
+              {userRole === "ADMINISTRATOR" && "🛡"}
             </span>
           </button>
         </ContextMenuTrigger>
@@ -141,12 +143,12 @@ export function SidebarButton({
           </ContextMenuItem>
           {(myRole === "ADMINISTRATOR" || myRole === "OWNER") &&
             myInfo.userId !== user.id && (
-              <ContextMenuItem inset disabled={isOwner}>
+              <ContextMenuItem inset disabled={userRole === "OWNER"}>
                 <button onClick={() => kickUser(roomId, user)}>Kick</button>
               </ContextMenuItem>
             )}
           {myRole === "OWNER" && myInfo.userId !== user.id && (
-            <ContextMenuItem inset disabled={isOwner}>
+            <ContextMenuItem inset disabled={userRole === "OWNER"}>
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="terms"

--- a/frontend/app/room/sidebar.tsx
+++ b/frontend/app/room/sidebar.tsx
@@ -1,0 +1,48 @@
+import { Stack } from "@/app/ui/layout/stack";
+import type { User } from "@/app/ui/user/card";
+import { SidebarButton } from "./sidebar-button";
+
+export type UserOnRoom = {
+  id: number;
+  userId: number;
+  role: string;
+  roomId: number;
+};
+
+export type UserWithRole<T> = T & {
+  role: "MEMBER" | "ADMINISTRATOR" | "OWNER";
+};
+
+export async function Sidebar({
+  roomId,
+  myInfo,
+  users,
+}: {
+  roomId: number;
+  myInfo: UserOnRoom;
+  users: UserWithRole<User>[];
+}) {
+  if (users.length === 0) {
+    return (
+      <div className="overflow-y-auto shrink-0 basis-36 pb-4">
+        <span className="text-muted-foreground text-sm whitespace-nowrap">
+          No users found
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-y-auto shrink-0 basis-36 pb-4">
+      <Stack spacing={2}>
+        {users.map((user, index) => (
+          <SidebarButton
+            roomId={roomId}
+            user={user}
+            myInfo={myInfo}
+            key={user.id}
+          />
+        ))}
+      </Stack>
+    </div>
+  );
+}

--- a/frontend/components/ui/checkbox.tsx
+++ b/frontend/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-context-menu": "^2.1.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",


### PR DESCRIPTION
[frontend]
- ownerがadminの付与とkick、adminがkickをできるように変更しました。
- 雑にownerとadminのuser名の横に識別マークをつけました。

[backend]
- kickとrole付与のsocketイベントハンドラーを追加しました。

sidebarとsidebar-buttonは取り敢えず/roomの下に複製してロジックを追加しています。
shadcn/uiからcheckboxを追加しました。
kickされたユーザーに部屋から追い出した後にkickされたことを伝える情報を表示したいが実装できてません。(room一覧の画面に飛ばすだけにしています)

<img width="1440" alt="スクリーンショット 2023-12-12 0 50 43" src="https://github.com/usatie/pong/assets/90199432/44f34ea5-4f08-4529-a042-9e924ffaf94d">
<img width="1440" alt="スクリーンショット 2023-12-12 0 51 04" src="https://github.com/usatie/pong/assets/90199432/2792f0f0-8408-4a0c-8c0f-91cecaffcc63">
<img width="1440" alt="スクリーンショット 2023-12-12 0 51 11" src="https://github.com/usatie/pong/assets/90199432/8e92e110-17f3-4fa4-b07a-6912f4e783e0">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced role management in chat rooms, allowing for user roles to be updated.
  - Added the ability to kick users from chat rooms.
  - Implemented new UI elements for role-based actions within chat rooms.

- **Enhancements**
  - Improved error handling for user and room validation.
  - Reorganized user interface components for better usability.

- **Bug Fixes**
  - Fixed issues related to user and room information retrieval.

- **Refactor**
  - Reorganized imports and updated logic in various components for clarity and maintainability.

- **Style**
  - Added new styles for role management UI elements.

- **Documentation**
  - Updated documentation to reflect new functions and component changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->