### PR TITLE
@CurrentUser @Memberなどのカスタムデコレーターを追加

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {
   ApiBearerAuth,
@@ -16,9 +9,10 @@ import {
 import { AuthEntity } from './entity/auth.entity';
 import { LoginDto } from './dto/login.dto';
 import { JwtGuardWithout2FA } from './jwt-auth.guard';
-import { User } from '@prisma/client';
+import type { User } from '@prisma/client';
 import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
 import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
+import { CurrentUser } from 'src/common/current-user.decorator';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -35,11 +29,9 @@ export class AuthController {
   @UseGuards(JwtGuardWithout2FA)
   @ApiBearerAuth()
   @ApiCreatedResponse()
-  async generate2FASecret(@Req() request: { user: User }) {
+  async generate2FASecret(@CurrentUser() user: User) {
     const { secret, otpAuthUrl } =
-      await this.authService.generateTwoFactorAuthenticationSecret(
-        request.user.id,
-      );
+      await this.authService.generateTwoFactorAuthenticationSecret(user.id);
     return {
       secret,
       otpAuthUrl,
@@ -53,9 +45,9 @@ export class AuthController {
   @ApiOkResponse()
   async enable2FA(
     @Body() dto: TwoFactorAuthenticationEnableDto,
-    @Req() request: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.authService.enableTwoFactorAuthentication(dto, request.user.id);
+    return this.authService.enableTwoFactorAuthentication(dto, user.id);
   }
 
   @Post('2fa/authenticate')
@@ -65,8 +57,8 @@ export class AuthController {
   @ApiOkResponse()
   async twoFactorAuthenticate(
     @Body() dto: TwoFactorAuthenticationDto,
-    @Req() request: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.authService.twoFactorAuthenticate(dto, request.user.id);
+    return this.authService.twoFactorAuthenticate(dto, user.id);
   }
 }

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -2,13 +2,14 @@ import {
   Controller,
   Get,
   Param,
-  Req,
   ParseIntPipe,
   UseGuards,
 } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { CurrentUser } from 'src/common/current-user.decorator';
+import { User } from '@prisma/client';
 
 @Controller('chat')
 @ApiTags('chat')
@@ -20,8 +21,8 @@ export class ChatController {
   @ApiBearerAuth()
   findConversation(
     @Param('userId', ParseIntPipe) userId: number,
-    @Req() request: Request,
+    @CurrentUser() user: User,
   ) {
-    return this.chatService.findConversation(userId, request['user']);
+    return this.chatService.findConversation(userId, user);
   }
 }

--- a/backend/src/common/current-user.decorator.ts
+++ b/backend/src/common/current-user.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '@prisma/client';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): User => {
+    data; // To remove the unused variable warning
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/backend/src/common/current-user.decorator.ts
+++ b/backend/src/common/current-user.decorator.ts
@@ -4,7 +4,7 @@ import { User } from '@prisma/client';
 export const CurrentUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): User => {
     data; // To remove the unused variable warning
-    const request = ctx.switchToHttp().getRequest();
-    return request.user;
+    const req = ctx.switchToHttp().getRequest();
+    return req.user;
   },
 );

--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -6,7 +6,6 @@ import {
   Patch,
   Param,
   UseGuards,
-  Req,
   ParseIntPipe,
 } from '@nestjs/common';
 import { FriendRequestService } from './friend-request.service';
@@ -21,6 +20,7 @@ import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { User } from '@prisma/client';
 import { UserEntity } from 'src/user/entities/user.entity';
 import { UserGuard } from 'src/user/user.guard';
+import { CurrentUser } from 'src/common/current-user.decorator';
 
 @Controller('user/:userId/friendrequest')
 @UseGuards(JwtAuthGuard, UserGuard)
@@ -34,16 +34,16 @@ export class FriendRequestController {
   @ApiCreatedResponse()
   create(
     @Body() createFriendRequestDto: CreateFriendRequestDto,
-    @Req() req: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.friendRequestService.create(createFriendRequestDto, req.user);
+    return this.friendRequestService.create(createFriendRequestDto, user);
   }
 
   // Get all friend requests for a user
   @Get()
   @ApiOkResponse({ type: [UserEntity] })
-  async findAll(@Req() req: { user: User }) {
-    const users = await this.friendRequestService.findAll(req.user);
+  async findAll(@CurrentUser() user: User) {
+    const users = await this.friendRequestService.findAll(user);
     return users.map((user) => new UserEntity(user));
   }
 
@@ -52,9 +52,9 @@ export class FriendRequestController {
   @ApiOkResponse()
   accept(
     @Param('requesterId', ParseIntPipe) requesterId: number,
-    @Req() req: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.friendRequestService.accept(requesterId, req.user);
+    return this.friendRequestService.accept(requesterId, user);
   }
 
   // Reject a friend request
@@ -62,9 +62,9 @@ export class FriendRequestController {
   @ApiOkResponse()
   reject(
     @Param('requesterId', ParseIntPipe) requesterId: number,
-    @Req() req: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.friendRequestService.reject(requesterId, req.user);
+    return this.friendRequestService.reject(requesterId, user);
   }
 
   // Cancel a friend request
@@ -72,8 +72,8 @@ export class FriendRequestController {
   @ApiOkResponse()
   cancel(
     @Param('recipientId', ParseIntPipe) recipientId: number,
-    @Req() req: { user: User },
+    @CurrentUser() user: User,
   ) {
-    return this.friendRequestService.cancel(recipientId, req.user);
+    return this.friendRequestService.cancel(recipientId, user);
   }
 }

--- a/backend/src/room/current-role.decorator.ts
+++ b/backend/src/room/current-role.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Role } from '@prisma/client';
+
+export const CurrentRole = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): Role => {
+    data; // To remove the unused variable warning
+    const req = ctx.switchToHttp().getRequest();
+    return req.role;
+  },
+);

--- a/backend/src/room/member.decorator.ts
+++ b/backend/src/room/member.decorator.ts
@@ -1,10 +1,10 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { Role } from '@prisma/client';
+import { UserOnRoom } from '@prisma/client';
 
-export const CurrentRole = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext): Role => {
+export const Member = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): UserOnRoom => {
     data; // To remove the unused variable warning
     const req = ctx.switchToHttp().getRequest();
-    return req.role;
+    return req.member;
   },
 );

--- a/backend/src/room/member.guard.ts
+++ b/backend/src/room/member.guard.ts
@@ -26,9 +26,17 @@ export class MemberGuard implements CanActivate {
         Number(roomId),
         user.id,
       );
+      // If userOnRoom is found, add it to the request object
+      // so that it can be accessed in the controller
       req.member = userOnRoom;
     } catch (e) {
-      throw new ForbiddenException('You are not a member of this room');
+      if (e.code === 'P2025') {
+        // If userOnRoom is not found, throw a ForbiddenException
+        throw new ForbiddenException('You are not a member of this room');
+      } else {
+        // Otherwise, throw the error
+        throw e;
+      }
     }
     return true;
   }

--- a/backend/src/room/member.guard.ts
+++ b/backend/src/room/member.guard.ts
@@ -38,9 +38,8 @@ export class MemberGuard implements CanActivate {
         Number(roomId),
         user.id,
       );
-      req.userRole = userOnRoom.role;
+      req.role = userOnRoom.role;
     } catch (e) {
-      console.log(e);
       throw new ForbiddenException('You are not a member of this room');
     }
     return true;

--- a/backend/src/room/member.guard.ts
+++ b/backend/src/room/member.guard.ts
@@ -3,17 +3,9 @@ import {
   CanActivate,
   ExecutionContext,
   BadRequestException,
-  UnauthorizedException,
   ForbiddenException,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
 import { RoomService } from './room.service';
-import { Role } from '@prisma/client';
-
-interface User {
-  id: number;
-  name: string;
-}
 
 @Injectable()
 export class MemberGuard implements CanActivate {
@@ -38,7 +30,7 @@ export class MemberGuard implements CanActivate {
         Number(roomId),
         user.id,
       );
-      req.role = userOnRoom.role;
+      req.member = userOnRoom;
     } catch (e) {
       throw new ForbiddenException('You are not a member of this room');
     }

--- a/backend/src/room/member.guard.ts
+++ b/backend/src/room/member.guard.ts
@@ -22,7 +22,7 @@ export class MemberGuard implements CanActivate {
   async canActivate(context: ExecutionContext) {
     const req = context.switchToHttp().getRequest();
     const { params, user } = req;
-    const { id: roomId } = params;
+    const { roomId } = params;
     if (!roomId) {
       console.log('MemberGuard should only be used on routes with a roomId');
       throw new Error(

--- a/backend/src/room/member.guard.ts
+++ b/backend/src/room/member.guard.ts
@@ -16,13 +16,9 @@ export class MemberGuard implements CanActivate {
     const { params, user } = req;
     const { roomId } = params;
     if (!roomId) {
-      console.log('MemberGuard should only be used on routes with a roomId');
-      throw new Error(
-        'MemberGuard should only be used on routes with a roomId',
-      );
+      throw new Error('MemberGuard should only be used with :roomId');
     }
     if (typeof roomId !== 'string' || !/^\d+$/.test(roomId)) {
-      console.log('roomId is not a valid integer');
       throw new BadRequestException('roomId parameter must be a valid integer');
     }
     try {

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -40,7 +40,7 @@ export class RoomController {
   @Post()
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiCreatedResponse({ type: CreateRoomDto })
+  @ApiCreatedResponse({ type: RoomEntity })
   async create(
     @Body() createRoomDto: CreateRoomDto,
     @CurrentUser() user: User,

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -27,6 +27,8 @@ import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
 import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { MemberGuard } from './member.guard';
 import { ChatService } from 'src/chat/chat.service';
+import { CurrentUser } from 'src/common/current-user.decorator';
+import { User } from '@prisma/client';
 
 @Controller('room')
 @ApiTags('room')
@@ -39,9 +41,12 @@ export class RoomController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiCreatedResponse({ type: CreateRoomDto })
-  async create(@Body() createRoomDto: CreateRoomDto, @Req() req: { user }) {
-    const res = await this.roomService.create(createRoomDto, req.user);
-    this.chatService.addUserToRoom(res.id, req.user);
+  async create(
+    @Body() createRoomDto: CreateRoomDto,
+    @CurrentUser() user: User,
+  ) {
+    const res = await this.roomService.create(createRoomDto, user);
+    this.chatService.addUserToRoom(res.id, user);
     return res;
   }
 
@@ -86,10 +91,10 @@ export class RoomController {
   @ApiOkResponse({ type: RoomEntity })
   async createUserOnRoom(
     @Param('id', ParseIntPipe) id: number,
-    @Req() request: Request,
+    @CurrentUser() user: User,
   ) {
-    const res = await this.roomService.createUserOnRoom(id, request['user']);
-    this.chatService.addUserToRoom(id, request['user']);
+    const res = await this.roomService.createUserOnRoom(id, user);
+    this.chatService.addUserToRoom(id, user);
     return res;
   }
 
@@ -112,13 +117,14 @@ export class RoomController {
   async deleteUserOnRoom(
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
+    @CurrentUser() user: User,
     @Req() request: Request,
   ) {
     await this.roomService.removeUserOnRoom(
       id,
       request['userRole'],
       userId,
-      request['user'],
+      user,
     );
   }
 

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -27,8 +27,8 @@ import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { MemberGuard } from './member.guard';
 import { ChatService } from 'src/chat/chat.service';
 import { CurrentUser } from 'src/common/current-user.decorator';
-import { Role, User } from '@prisma/client';
-import { CurrentRole } from './current-role.decorator';
+import { User } from '@prisma/client';
+import { Member } from './member.decorator';
 
 @Controller('room')
 @ApiTags('room')
@@ -60,8 +60,8 @@ export class RoomController {
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
-  findOne(@Param('roomId', ParseIntPipe) roomId: number) {
-    return this.roomService.findRoom(roomId);
+  findOne(@Member() member: UserOnRoomEntity) {
+    return this.roomService.findRoom(member.roomId);
   }
 
   @Patch(':roomId')
@@ -69,11 +69,14 @@ export class RoomController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
   update(
-    @Param('roomId', ParseIntPipe) roomId: number,
     @Body() updateRoomDto: UpdateRoomDto,
-    @CurrentRole() role: Role,
+    @Member() member: UserOnRoomEntity,
   ) {
-    return this.roomService.updateRoom(roomId, updateRoomDto, role);
+    return this.roomService.updateRoom(
+      member.roomId,
+      updateRoomDto,
+      member.role,
+    );
   }
 
   @Delete(':roomId')
@@ -83,9 +86,9 @@ export class RoomController {
   @ApiNoContentResponse()
   removeRoom(
     @Param('roomId', ParseIntPipe) roomId: number,
-    @CurrentRole() role: Role,
+    @Member() member: UserOnRoomEntity,
   ) {
-    return this.roomService.removeRoom(roomId, role);
+    return this.roomService.removeRoom(member.roomId, member.role);
   }
 
   @Post(':roomId')
@@ -106,10 +109,10 @@ export class RoomController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   getUserOnRoom(
-    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
+    @Member() member: UserOnRoomEntity,
   ) {
-    return this.roomService.findUserOnRoom(roomId, userId);
+    return this.roomService.findUserOnRoom(member.roomId, userId);
   }
 
   @Delete(':roomId/:userId')
@@ -118,12 +121,16 @@ export class RoomController {
   @ApiBearerAuth()
   @ApiNoContentResponse()
   async deleteUserOnRoom(
-    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
     @CurrentUser() user: User,
-    @CurrentRole() role: Role,
+    @Member() member: UserOnRoomEntity,
   ) {
-    await this.roomService.removeUserOnRoom(roomId, role, userId, user);
+    await this.roomService.removeUserOnRoom(
+      member.roomId,
+      member.role,
+      userId,
+      user,
+    );
   }
 
   @Patch(':roomId/:userId')
@@ -131,14 +138,13 @@ export class RoomController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   updateUserOnRoom(
-    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
     @Body() updateUserOnRoomDto: UpdateUserOnRoomDto,
-    @CurrentRole() role: Role,
+    @Member() member: UserOnRoomEntity,
   ) {
     return this.roomService.updateUserOnRoom(
-      roomId,
-      role,
+      member.roomId,
+      member.role,
       userId,
       updateUserOnRoomDto,
     );

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -9,7 +9,6 @@ import {
   ParseIntPipe,
   UseGuards,
   HttpCode,
-  Req,
 } from '@nestjs/common';
 import { RoomService } from './room.service';
 import { CreateRoomDto } from './dto/create-room.dto';
@@ -28,7 +27,8 @@ import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { MemberGuard } from './member.guard';
 import { ChatService } from 'src/chat/chat.service';
 import { CurrentUser } from 'src/common/current-user.decorator';
-import { User } from '@prisma/client';
+import { Role, User } from '@prisma/client';
+import { CurrentRole } from './current-role.decorator';
 
 @Controller('room')
 @ApiTags('room')
@@ -71,9 +71,9 @@ export class RoomController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateRoomDto: UpdateRoomDto,
-    @Req() request: Request,
+    @CurrentRole() role: Role,
   ) {
-    return this.roomService.updateRoom(id, updateRoomDto, request['userRole']);
+    return this.roomService.updateRoom(id, updateRoomDto, role);
   }
 
   @Delete(':id')
@@ -81,8 +81,8 @@ export class RoomController {
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
-  removeRoom(@Param('id', ParseIntPipe) id: number, @Req() request: Request) {
-    return this.roomService.removeRoom(id, request['userRole']);
+  removeRoom(@Param('id', ParseIntPipe) id: number, @CurrentRole() role: Role) {
+    return this.roomService.removeRoom(id, role);
   }
 
   @Post(':id')
@@ -118,14 +118,9 @@ export class RoomController {
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
     @CurrentUser() user: User,
-    @Req() request: Request,
+    @CurrentRole() role: Role,
   ) {
-    await this.roomService.removeUserOnRoom(
-      id,
-      request['userRole'],
-      userId,
-      user,
-    );
+    await this.roomService.removeUserOnRoom(id, role, userId, user);
   }
 
   @Patch(':id/:userId')
@@ -136,11 +131,11 @@ export class RoomController {
     @Param('id', ParseIntPipe) id: number,
     @Param('userId', ParseIntPipe) userId: number,
     @Body() updateUserOnRoomDto: UpdateUserOnRoomDto,
-    @Req() request: Request,
+    @CurrentRole() role: Role,
   ) {
     return this.roomService.updateUserOnRoom(
       id,
-      request['userRole'],
+      role,
       userId,
       updateUserOnRoomDto,
     );

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -45,9 +45,9 @@ export class RoomController {
     @Body() createRoomDto: CreateRoomDto,
     @CurrentUser() user: User,
   ) {
-    const res = await this.roomService.create(createRoomDto, user);
-    this.chatService.addUserToRoom(res.id, user);
-    return res;
+    const room = await this.roomService.create(createRoomDto, user);
+    this.chatService.addUserToRoom(room.id, user);
+    return room;
   }
 
   @Get()
@@ -56,85 +56,88 @@ export class RoomController {
     return this.roomService.findAllRoom();
   }
 
-  @Get(':id')
+  @Get(':roomId')
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.roomService.findRoom(id);
+  findOne(@Param('roomId', ParseIntPipe) roomId: number) {
+    return this.roomService.findRoom(roomId);
   }
 
-  @Patch(':id')
+  @Patch(':roomId')
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
   update(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('roomId', ParseIntPipe) roomId: number,
     @Body() updateRoomDto: UpdateRoomDto,
     @CurrentRole() role: Role,
   ) {
-    return this.roomService.updateRoom(id, updateRoomDto, role);
+    return this.roomService.updateRoom(roomId, updateRoomDto, role);
   }
 
-  @Delete(':id')
+  @Delete(':roomId')
   @HttpCode(204)
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
-  removeRoom(@Param('id', ParseIntPipe) id: number, @CurrentRole() role: Role) {
-    return this.roomService.removeRoom(id, role);
+  removeRoom(
+    @Param('roomId', ParseIntPipe) roomId: number,
+    @CurrentRole() role: Role,
+  ) {
+    return this.roomService.removeRoom(roomId, role);
   }
 
-  @Post(':id')
+  @Post(':roomId')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: RoomEntity })
   async createUserOnRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('roomId', ParseIntPipe) roomId: number,
     @CurrentUser() user: User,
   ) {
-    const res = await this.roomService.createUserOnRoom(id, user);
-    this.chatService.addUserToRoom(id, user);
+    const res = await this.roomService.createUserOnRoom(roomId, user);
+    this.chatService.addUserToRoom(roomId, user);
     return res;
   }
 
-  @Get(':id/:userId')
+  @Get(':roomId/:userId')
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   getUserOnRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
   ) {
-    return this.roomService.findUserOnRoom(id, userId);
+    return this.roomService.findUserOnRoom(roomId, userId);
   }
 
-  @Delete(':id/:userId')
+  @Delete(':roomId/:userId')
   @HttpCode(204)
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiNoContentResponse()
   async deleteUserOnRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
     @CurrentUser() user: User,
     @CurrentRole() role: Role,
   ) {
-    await this.roomService.removeUserOnRoom(id, role, userId, user);
+    await this.roomService.removeUserOnRoom(roomId, role, userId, user);
   }
 
-  @Patch(':id/:userId')
+  @Patch(':roomId/:userId')
   @UseGuards(JwtAuthGuard, MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse({ type: UserOnRoomEntity })
   updateUserOnRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('roomId', ParseIntPipe) roomId: number,
     @Param('userId', ParseIntPipe) userId: number,
     @Body() updateUserOnRoomDto: UpdateUserOnRoomDto,
     @CurrentRole() role: Role,
   ) {
     return this.roomService.updateUserOnRoom(
-      id,
+      roomId,
       role,
       userId,
       updateUserOnRoomDto,


### PR DESCRIPTION
`req.user`とか`req['user']`とか`req['userRole']`などと書いているところを、カスタムデコレータに変更しました。

Before
```
handler(@Req() req) {
 this.service.hoge(req.user);
}
```

After
```
handler(@CurrentUser() user) {
 this.service.hoge(user);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Reorganized import statements for better readability and maintenance.
	- Updated method signatures to use the new `@CurrentUser` decorator, enhancing code clarity and security.
	- Introduced new decorators `@CurrentUser()` and `@Member()` for improved request context handling.

- **Bug Fixes**
	- Ensured consistent user object retrieval across all endpoints, potentially fixing bugs related to user authentication and authorization. 

- **Documentation**
	- Added inline comments explaining the use of the `@CurrentUser` decorator within the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->