### PR TITLE
`getCurrentUserId` がエラーを出す代わりにログイン画面へリダイレクト

### DIFF
--- a/frontend/app/lib/session.ts
+++ b/frontend/app/lib/session.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import * as jose from "jose";
 import { getUser } from "./actions";
+import { redirect } from "next/navigation";
 
 // TODO: add types
 export type Session = {};
@@ -38,13 +39,13 @@ export async function getCurrentUser(): Promise<any> {
 export async function getCurrentUserId(): Promise<number> {
   const payload = await getAccessTokenPayload({ ignoreExpiration: true });
   const userId = payload?.userId?.toString();
-  // If userId is not set, then return null
+  // If userId is not set, then redirect to login page
   if (!userId) {
-    throw new Error("userId is not set");
+    redirect("/login");
   }
-  // If invalid userId, then return null
+  // If invalid userId, then redirect to login page
   if (!userId.match(/^[0-9]+$/)) {
-    throw new Error("invalid userId");
+    redirect("/login");
   }
   return parseInt(userId);
 }

--- a/frontend/app/ui/login-form.tsx
+++ b/frontend/app/ui/login-form.tsx
@@ -4,14 +4,9 @@ import { useFormState, useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { authenticate } from "@/app/lib/actions";
+import { useAuthContext } from "../lib/client-auth";
 
 export default function LoginForm() {
   return (
@@ -29,6 +24,7 @@ export default function LoginForm() {
 }
 
 function Form() {
+  const { currentUser } = useAuthContext();
   const [code, action] = useFormState(authenticate, undefined);
   return (
     <>
@@ -41,6 +37,7 @@ function Form() {
               type="email"
               name="email"
               placeholder="Enter your email address"
+              defaultValue={currentUser?.email}
             />
           </div>
           <div className="flex flex-col space-y-1.5">


### PR DESCRIPTION
ログイン画面で単にtokenがexpiredだった時には、デフォルトでemailを表示するようにというのもやった
（本当はemail自体をlocal storageやcookieなどに保存した方がいいかな）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined imports for better code organization and maintenance.

- **New Features**
  - Login form now pre-populates the email field if the current user is detected, enhancing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->