### PR TITLE
[format] Organize imports with prettier

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,16 +1,16 @@
 import { Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { UserModule } from './user/user.module';
-import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
-import { RoomModule } from './room/room.module';
-import { EventsModule } from './events/events.module';
-import { ChatModule } from './chat/chat.module';
-import { FriendRequestModule } from './friend-request/friend-request.module';
 import { AvatarModule } from './avatar/avatar.module';
+import { ChatModule } from './chat/chat.module';
+import { EventsModule } from './events/events.module';
+import { FriendRequestModule } from './friend-request/friend-request.module';
 import { HistoryModule } from './history/history.module';
-import { EventEmitterModule } from '@nestjs/event-emitter';
+import { PrismaModule } from './prisma/prisma.module';
+import { RoomModule } from './room/room.module';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,8 +1,8 @@
+import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { PrismaService } from 'src/prisma/prisma.service';
-import { JwtService } from '@nestjs/jwt';
 
 describe('AuthController', () => {
   let controller: AuthController;

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,18 +1,18 @@
 import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
-import { AuthService } from './auth.service';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthEntity } from './entity/auth.entity';
-import { LoginDto } from './dto/login.dto';
-import { JwtGuardWithout2FA } from './jwt-auth.guard';
 import type { User } from '@prisma/client';
-import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
-import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
+import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
+import { AuthEntity } from './entity/auth.entity';
+import { JwtGuardWithout2FA } from './jwt-auth.guard';
 
 @Controller('auth')
 @ApiTags('auth')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { AuthController } from './auth.controller';
-import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { UserModule } from 'src/user/user.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 import { JwtStrategy, JwtWithout2FAStrategy } from './jwt.strategy';
 
 export const jwtConstants = {

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AuthService } from './auth.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,16 +4,16 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
-import { AuthEntity } from './entity/auth.entity';
-import * as bcrypt from 'bcrypt';
 import { User } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
 import { authenticator } from 'otplib';
 import { toFileStream } from 'qrcode';
-import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
-import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { jwtConstants } from './auth.module';
+import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
+import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
+import { AuthEntity } from './entity/auth.entity';
 
 @Injectable()
 export class AuthService {

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,8 +1,8 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy, ExtractJwt } from 'passport-jwt';
-import { jwtConstants } from './auth.module';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserService } from 'src/user/user.service';
+import { jwtConstants } from './auth.module';
 
 @Injectable()
 export class JwtWithout2FAStrategy extends PassportStrategy(

--- a/backend/src/avatar/avatar.controller.spec.ts
+++ b/backend/src/avatar/avatar.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { AvatarController } from './avatar.controller';
 import { AvatarService } from './avatar.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('AvatarController', () => {
   let controller: AvatarController;

--- a/backend/src/avatar/avatar.controller.ts
+++ b/backend/src/avatar/avatar.controller.ts
@@ -1,20 +1,18 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
+  Controller,
   Delete,
-  UseGuards,
-  Param,
-  Res,
-  UseInterceptors,
-  UploadedFile,
-  ParseIntPipe,
+  Get,
   HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
-import { AvatarService } from './avatar.service';
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
-import { UserGuard } from 'src/user/user.guard';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBearerAuth,
   ApiConsumes,
@@ -22,8 +20,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Response } from 'express';
-import { FileInterceptor } from '@nestjs/platform-express';
 import * as multer from 'multer';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { UserGuard } from 'src/user/user.guard';
+import { AvatarService } from './avatar.service';
 import { CreateAvatarDto } from './dto/create-avatar.dto';
 
 @Controller()

--- a/backend/src/avatar/avatar.module.ts
+++ b/backend/src/avatar/avatar.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { AvatarService } from './avatar.service';
-import { AvatarController } from './avatar.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { AvatarController } from './avatar.controller';
+import { AvatarService } from './avatar.service';
 
 @Module({
   controllers: [AvatarController],

--- a/backend/src/avatar/avatar.service.spec.ts
+++ b/backend/src/avatar/avatar.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AvatarService } from './avatar.service';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { AvatarService } from './avatar.service';
 
 describe('AvatarService', () => {
   let service: AvatarService;

--- a/backend/src/avatar/avatar.service.ts
+++ b/backend/src/avatar/avatar.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
 import * as fs from 'fs';
 import * as path from 'path';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
 export class AvatarService {

--- a/backend/src/chat/chat.controller.spec.ts
+++ b/backend/src/chat/chat.controller.spec.ts
@@ -1,9 +1,9 @@
+import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from 'src/auth/auth.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
-import { PrismaService } from 'src/prisma/prisma.service';
-import { AuthService } from 'src/auth/auth.service';
-import { JwtService } from '@nestjs/jwt';
 
 describe('ChatController', () => {
   let controller: ChatController;

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -5,11 +5,11 @@ import {
   ParseIntPipe,
   UseGuards,
 } from '@nestjs/common';
-import { ChatService } from './chat.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { User } from '@prisma/client';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { User } from '@prisma/client';
+import { ChatService } from './chat.service';
 
 @Controller('chat')
 @ApiTags('chat')

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
@@ -6,10 +7,9 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger } from '@nestjs/common';
+import { UserService } from '../user/user.service';
 import { ChatService } from './chat.service';
 import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
-import { UserService } from '../user/user.service';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { MessageEntity } from './entities/message.entity';
 

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ChatService } from './chat.service';
-import { ChatController } from './chat.controller';
-import { ChatGateway } from './chat.gateway';
+import { AuthModule } from 'src/auth/auth.module';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { UserService } from '../user/user.service';
-import { AuthModule } from 'src/auth/auth.module';
+import { ChatController } from './chat.controller';
+import { ChatGateway } from './chat.gateway';
+import { ChatService } from './chat.service';
 
 @Module({
   controllers: [ChatController],

--- a/backend/src/chat/chat.service.spec.ts
+++ b/backend/src/chat/chat.service.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ChatService } from './chat.service';
-import { PrismaService } from 'src/prisma/prisma.service';
-import { AuthService } from 'src/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from 'src/auth/auth.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { ChatService } from './chat.service';
 
 describe('ChatService', () => {
   let service: ChatService;

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WebSocketGateway, WsException } from '@nestjs/websockets';
 import { User } from '@prisma/client';
 import { Socket } from 'socket.io';
-import { WebSocketGateway, WsException } from '@nestjs/websockets';
 import { AuthService } from 'src/auth/auth.service';
-import { CreateMessageDto } from './dto/create-message.dto';
-import { OnEvent } from '@nestjs/event-emitter';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
+import { CreateMessageDto } from './dto/create-message.dto';
 
 @Injectable()
 @WebSocketGateway()

--- a/backend/src/chat/dto/create-direct-message.dto.ts
+++ b/backend/src/chat/dto/create-direct-message.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class CreateDirectMessageDto {
   @IsString()

--- a/backend/src/chat/dto/create-message.dto.ts
+++ b/backend/src/chat/dto/create-message.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class CreateMessageDto {
   @IsString()

--- a/backend/src/events/events.gateway.ts
+++ b/backend/src/events/events.gateway.ts
@@ -1,11 +1,11 @@
 import { Logger } from '@nestjs/common';
 import {
+  ConnectedSocket,
   MessageBody,
+  OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
-  ConnectedSocket,
-  OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Namespace, Socket } from 'socket.io';
 

--- a/backend/src/events/pong-match.gateway.ts
+++ b/backend/src/events/pong-match.gateway.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@nestjs/common';
 import {
+  ConnectedSocket,
+  OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
-  ConnectedSocket,
-  OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Namespace, Socket } from 'socket.io';
 import { v4 } from 'uuid';

--- a/backend/src/friend-request/friend-request.controller.spec.ts
+++ b/backend/src/friend-request/friend-request.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { FriendRequestController } from './friend-request.controller';
 import { FriendRequestService } from './friend-request.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('FriendRequestController', () => {
   let controller: FriendRequestController;

--- a/backend/src/friend-request/friend-request.controller.ts
+++ b/backend/src/friend-request/friend-request.controller.ts
@@ -1,26 +1,26 @@
 import {
+  Body,
   Controller,
   Get,
-  Post,
-  Body,
-  Patch,
   Param,
-  UseGuards,
   ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
 } from '@nestjs/common';
-import { FriendRequestService } from './friend-request.service';
-import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { User } from '@prisma/client';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { UserEntity } from 'src/user/entities/user.entity';
 import { UserGuard } from 'src/user/user.guard';
-import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
+import { FriendRequestService } from './friend-request.service';
 
 @Controller('user/:userId/friendrequest')
 @UseGuards(JwtAuthGuard, UserGuard)

--- a/backend/src/friend-request/friend-request.module.ts
+++ b/backend/src/friend-request/friend-request.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { FriendRequestService } from './friend-request.service';
-import { FriendRequestController } from './friend-request.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { FriendRequestController } from './friend-request.controller';
+import { FriendRequestService } from './friend-request.service';
 
 @Module({
   controllers: [FriendRequestController],

--- a/backend/src/friend-request/friend-request.service.spec.ts
+++ b/backend/src/friend-request/friend-request.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { FriendRequestService } from './friend-request.service';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { FriendRequestService } from './friend-request.service';
 
 describe('FriendRequestService', () => {
   let service: FriendRequestService;

--- a/backend/src/friend-request/friend-request.service.ts
+++ b/backend/src/friend-request/friend-request.service.ts
@@ -4,9 +4,9 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
 import { User } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateFriendRequestDto } from './dto/create-friend-request.dto';
 
 @Injectable()
 export class FriendRequestService {

--- a/backend/src/history/history.controller.spec.ts
+++ b/backend/src/history/history.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { HistoryController } from './history.controller';
 import { HistoryService } from './history.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('HistoryController', () => {
   let controller: HistoryController;

--- a/backend/src/history/history.controller.ts
+++ b/backend/src/history/history.controller.ts
@@ -1,14 +1,12 @@
 import {
+  Body,
   Controller,
   Get,
-  Post,
-  Body,
   Param,
-  UseGuards,
   ParseIntPipe,
+  Post,
+  UseGuards,
 } from '@nestjs/common';
-import { HistoryService } from './history.service';
-import { CreateHistoryDto } from './dto/create-history.dto';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
@@ -17,6 +15,8 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UserGuard } from 'src/user/user.guard';
+import { CreateHistoryDto } from './dto/create-history.dto';
+import { HistoryService } from './history.service';
 
 @Controller()
 @ApiTags('history')

--- a/backend/src/history/history.module.ts
+++ b/backend/src/history/history.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { HistoryService } from './history.service';
-import { HistoryController } from './history.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { HistoryController } from './history.controller';
+import { HistoryService } from './history.service';
 
 @Module({
   controllers: [HistoryController],

--- a/backend/src/history/history.service.spec.ts
+++ b/backend/src/history/history.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HistoryService } from './history.service';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { HistoryService } from './history.service';
 
 describe('HistoryService', () => {
   let service: HistoryService;

--- a/backend/src/history/history.service.ts
+++ b/backend/src/history/history.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { CreateHistoryDto } from './dto/create-history.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateHistoryDto } from './dto/create-history.dto';
 
 @Injectable()
 export class HistoryService {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,8 @@
-import { HttpAdapterHost, NestFactory, Reflector } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
+import { HttpAdapterHost, NestFactory, Reflector } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { PrismaClientExceptionFilter } from 'nestjs-prisma';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/backend/src/room/dto/create-UserOnRoom.dto.ts
+++ b/backend/src/room/dto/create-UserOnRoom.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty } from 'class-validator';
 import { Role } from '@prisma/client';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateUserOnRoomDto {
   @IsString()

--- a/backend/src/room/dto/create-room.dto.ts
+++ b/backend/src/room/dto/create-room.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateRoomDto {
   @IsString()

--- a/backend/src/room/entities/UserOnRoom.entity.ts
+++ b/backend/src/room/entities/UserOnRoom.entity.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UserOnRoom, Role } from '@prisma/client';
+import { Role, UserOnRoom } from '@prisma/client';
 
 export class UserOnRoomEntity implements UserOnRoom {
   constructor(partial: Partial<UserOnRoomEntity>) {

--- a/backend/src/room/entities/room.entity.ts
+++ b/backend/src/room/entities/room.entity.ts
@@ -1,5 +1,5 @@
-import { Room } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
+import { Room } from '@prisma/client';
 
 export class RoomEntity implements Room {
   constructor(partial: Partial<RoomEntity>) {

--- a/backend/src/room/guards/change-role.guard.ts
+++ b/backend/src/room/guards/change-role.guard.ts
@@ -1,9 +1,9 @@
 import {
-  Injectable,
+  BadRequestException,
   CanActivate,
   ExecutionContext,
-  BadRequestException,
   ForbiddenException,
+  Injectable,
 } from '@nestjs/common';
 import { Role } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';

--- a/backend/src/room/guards/kick.guard.ts
+++ b/backend/src/room/guards/kick.guard.ts
@@ -1,9 +1,9 @@
 import {
-  Injectable,
+  BadRequestException,
   CanActivate,
   ExecutionContext,
-  BadRequestException,
   ForbiddenException,
+  Injectable,
 } from '@nestjs/common';
 import { Role } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';

--- a/backend/src/room/guards/member.guard.ts
+++ b/backend/src/room/guards/member.guard.ts
@@ -1,9 +1,9 @@
 import {
-  Injectable,
+  BadRequestException,
   CanActivate,
   ExecutionContext,
-  BadRequestException,
   ForbiddenException,
+  Injectable,
 } from '@nestjs/common';
 import { RoomService } from '../room.service';
 

--- a/backend/src/room/guards/owner.guard.ts
+++ b/backend/src/room/guards/owner.guard.ts
@@ -1,9 +1,9 @@
 import {
-  Injectable,
+  BadRequestException,
   CanActivate,
   ExecutionContext,
-  BadRequestException,
   ForbiddenException,
+  Injectable,
 } from '@nestjs/common';
 import { Role } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';

--- a/backend/src/room/room.controller.spec.ts
+++ b/backend/src/room/room.controller.spec.ts
@@ -1,6 +1,6 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PrismaClient } from '@prisma/client';
 import { RoomService } from './room.service';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('RoomService', () => {
   it('should be defined', () => {

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -1,36 +1,36 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
-  ParseIntPipe,
-  UseGuards,
+  Get,
   HttpCode,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
 } from '@nestjs/common';
-import { RoomService } from './room.service';
-import { CreateRoomDto } from './dto/create-room.dto';
-import { UpdateRoomDto } from './dto/update-room.dto';
 import {
-  ApiTags,
-  ApiCreatedResponse,
-  ApiOkResponse,
   ApiBearerAuth,
+  ApiCreatedResponse,
   ApiNoContentResponse,
+  ApiOkResponse,
+  ApiTags,
 } from '@nestjs/swagger';
-import { RoomEntity } from './entities/room.entity';
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
-import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
-import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
-import { MemberGuard } from './guards/member.guard';
-import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { User } from '@prisma/client';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { Member } from './decorators/member.decorator';
-import { KickGuard } from './guards/kick.guard';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
+import { RoomEntity } from './entities/room.entity';
 import { ChangeRoleGuard } from './guards/change-role.guard';
+import { KickGuard } from './guards/kick.guard';
+import { MemberGuard } from './guards/member.guard';
 import { OwnerGuard } from './guards/owner.guard';
+import { RoomService } from './room.service';
 
 @Controller('room')
 @UseGuards(JwtAuthGuard)

--- a/backend/src/room/room.module.ts
+++ b/backend/src/room/room.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { RoomService } from './room.service';
-import { RoomController } from './room.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { RoomController } from './room.controller';
+import { RoomService } from './room.service';
 
 @Module({
   controllers: [RoomController],

--- a/backend/src/room/room.service.spec.ts
+++ b/backend/src/room/room.service.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { RoomService } from './room.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { RoomService } from './room.service';
 
 describe('RoomService', () => {
   let service: RoomService;

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { CreateRoomDto } from './dto/create-room.dto';
-import { UpdateRoomDto } from './dto/update-room.dto';
-import { PrismaService } from 'src/prisma/prisma.service';
-import { Role, User } from '@prisma/client';
-import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
-import { RoomEntity } from './entities/room.entity';
-import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Role, User } from '@prisma/client';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
 import { RoomLeftEvent } from 'src/common/events/room-left.event';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+import { UserOnRoomEntity } from './entities/UserOnRoom.entity';
+import { RoomEntity } from './entities/room.entity';
 
 @Injectable()
 export class RoomService {

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -3,8 +3,8 @@ import {
   IsEmail,
   IsNotEmpty,
   IsString,
-  MinLength,
   MaxLength,
+  MinLength,
 } from 'class-validator';
 
 export class CreateUserDto {

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -1,5 +1,5 @@
-import { User } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
 import { Exclude } from 'class-transformer';
 
 export class UserEntity implements User {

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
-import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('UserController', () => {
   let controller: UserController;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,28 +1,28 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
   HttpCode,
+  Param,
   ParseIntPipe,
+  Patch,
+  Post,
   UseGuards,
 } from '@nestjs/common';
-import { UserService } from './user.service';
-import { CreateUserDto } from './dto/create-user.dto';
-import { UpdateUserDto } from './dto/update-user.dto';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
-  ApiOkResponse,
   ApiNoContentResponse,
+  ApiOkResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { UserEntity } from './entities/user.entity';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UserEntity } from './entities/user.entity';
 import { UserGuard } from './user.guard';
+import { UserService } from './user.service';
 
 @Controller('user')
 @ApiTags('user')

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { UserService } from './user.service';
-import { UserController } from './user.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 @Module({
   controllers: [UserController],

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UserService } from './user.service';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { UserService } from './user.service';
 
 describe('UserService', () => {
   let service: UserService;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { CreateUserDto } from './dto/create-user.dto';
-import { UpdateUserDto } from './dto/update-user.dto';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { User } from '@prisma/client';
 import { hash } from 'bcrypt';
 import * as fs from 'fs';
 import * as path from 'path';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class UserService {

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { initializeApp } from './utils/initialize';
-import { constants } from './constants';
 import { authenticator } from 'otplib';
+import { constants } from './constants';
 import { TestApp } from './utils/app';
+import { initializeApp } from './utils/initialize';
 
 describe('AuthController (e2e)', () => {
   let app: TestApp;

--- a/backend/test/avatar.e2e-spec.ts
+++ b/backend/test/avatar.e2e-spec.ts
@@ -1,8 +1,8 @@
-import { initializeApp } from './utils/initialize';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 import { constants } from './constants';
 import { TestApp } from './utils/app';
+import { initializeApp } from './utils/initialize';
 import { expectFile } from './utils/matcher';
 
 describe('AvatarController (e2e)', () => {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -2,8 +2,8 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Socket, io } from 'socket.io-client';
 import { AppModule } from 'src/app.module';
-import { TestApp } from './utils/app';
 import { MessageEntity } from 'src/chat/entities/message.entity';
+import { TestApp } from './utils/app';
 
 async function createNestApp(): Promise<INestApplication> {
   const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/backend/test/constants/index.ts
+++ b/backend/test/constants/index.ts
@@ -1,5 +1,5 @@
-import * as user from './user';
 import * as room from './room';
+import * as user from './user';
 
 export const constants = {
   user,

--- a/backend/test/history.e2e-spec.ts
+++ b/backend/test/history.e2e-spec.ts
@@ -1,6 +1,6 @@
-import { initializeApp } from './utils/initialize';
 import { constants } from './constants';
 import { TestApp } from './utils/app';
+import { initializeApp } from './utils/initialize';
 import { expectHistoryResponse } from './utils/matcher';
 
 describe('HistoryController (e2e)', () => {

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -1,15 +1,15 @@
-import { RoomEntity } from 'src/room/entities/room.entity';
+import { Role } from '@prisma/client';
+import { UpdateUserOnRoomDto } from 'src/room/dto/update-UserOnRoom.dto';
 import { UpdateRoomDto } from 'src/room/dto/update-room.dto';
+import { RoomEntity } from 'src/room/entities/room.entity';
+import { constants } from './constants';
+import { TestApp } from './utils/app';
 import { initializeApp } from './utils/initialize';
 import {
   expectRoom,
   expectRoomWithUsers,
   expectUserOnRoom,
 } from './utils/matcher';
-import { constants } from './constants';
-import { Role } from '@prisma/client';
-import { UpdateUserOnRoomDto } from 'src/room/dto/update-UserOnRoom.dto';
-import { TestApp } from './utils/app';
 
 describe('RoomController (e2e)', () => {
   let app: TestApp;

--- a/backend/test/user.e2e-spec.ts
+++ b/backend/test/user.e2e-spec.ts
@@ -1,10 +1,10 @@
-import { initializeApp } from './utils/initialize';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { UpdateUserDto } from 'src/user/dto/update-user.dto';
-import { LoginDto } from 'src/auth/dto/login.dto';
-import { expectUser } from './utils/matcher';
 import { constants } from './constants';
 import { TestApp } from './utils/app';
+import { initializeApp } from './utils/initialize';
+import { expectUser } from './utils/matcher';
 
 describe('UserController (e2e)', () => {
   let app: TestApp;

--- a/backend/test/utils/app.ts
+++ b/backend/test/utils/app.ts
@@ -1,11 +1,11 @@
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
 import { LoginDto } from 'src/auth/dto/login.dto';
-import { UpdateRoomDto } from 'src/room/dto/update-room.dto';
 import { CreateRoomDto } from 'src/room/dto/create-room.dto';
-import { UpdateUserDto } from 'src/user/dto/update-user.dto';
-import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { UpdateUserOnRoomDto } from 'src/room/dto/update-UserOnRoom.dto';
+import { UpdateRoomDto } from 'src/room/dto/update-room.dto';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { UpdateUserDto } from 'src/user/dto/update-user.dto';
+import * as request from 'supertest';
 
 export class TestApp {
   constructor(private readonly app: INestApplication) {}

--- a/backend/test/utils/initialize.ts
+++ b/backend/test/utils/initialize.ts
@@ -1,9 +1,12 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import { AppModule } from '../../src/app.module';
-import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
-import { PrismaClientExceptionFilter } from 'nestjs-prisma';
+import {
+  ClassSerializerInterceptor,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
 import { HttpAdapterHost, Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaClientExceptionFilter } from 'nestjs-prisma';
+import { AppModule } from '../../src/app.module';
 
 export async function initializeApp(): Promise<INestApplication> {
   const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/backend/test/utils/matcher.ts
+++ b/backend/test/utils/matcher.ts
@@ -1,5 +1,5 @@
-import * as request from 'supertest';
 import * as fs from 'fs';
+import * as request from 'supertest';
 
 export const expectRoomWithUsers = (room) => {
   const expected = {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
-import AuthProvider from "./client-auth-provider";
 import { getCurrentUser, isLoggedIn } from "@/app/lib/session";
+import AuthProvider from "./client-auth-provider";
 
 // components
 import { ThemeProvider } from "@/components/theme-provider";

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -1,11 +1,11 @@
 "use server";
 
+import type { User } from "@/app/ui/user/card";
+import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect, RedirectType } from "next/navigation";
-import { revalidatePath } from "next/cache";
-import { destroySession, getCurrentUser, getCurrentUserId } from "./session";
-import type { User } from "@/app/ui/user/card";
 import { Room } from "../ui/room/card";
+import { destroySession, getCurrentUser, getCurrentUserId } from "./session";
 
 export async function signOut() {
   cookies()?.delete("token");

--- a/frontend/app/lib/client-actions.ts
+++ b/frontend/app/lib/client-actions.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { RedirectType, redirect } from "next/navigation";
 import { toast } from "@/components/ui/use-toast";
+import { RedirectType, redirect } from "next/navigation";
 
 export async function createUser(formData: FormData) {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/user`, {

--- a/frontend/app/lib/hooks/useUserMode.ts
+++ b/frontend/app/lib/hooks/useUserMode.ts
@@ -1,5 +1,5 @@
-import { useCallback } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
 
 export type UserModeType = "viewer" | "player";
 

--- a/frontend/app/lib/session.ts
+++ b/frontend/app/lib/session.ts
@@ -1,7 +1,7 @@
-import { cookies } from "next/headers";
 import * as jose from "jose";
-import { getUser } from "./actions";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getUser } from "./actions";
 
 // TODO: add types
 export type Session = {};

--- a/frontend/app/pong/JoinRoomForm.tsx
+++ b/frontend/app/pong/JoinRoomForm.tsx
@@ -1,18 +1,17 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
-import { FC, FormEvent, useState } from "react";
+import { useState } from "react";
 
 export default function JoinRoomForm() {
   const router = useRouter();

--- a/frontend/app/pong/MatchButton.tsx
+++ b/frontend/app/pong/MatchButton.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { io } from "socket.io-client";
-import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { io } from "socket.io-client";
 
 export default function MatchButton() {
   const router = useRouter();

--- a/frontend/app/pong/[id]/PongBoard.tsx
+++ b/frontend/app/pong/[id]/PongBoard.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { PongGame } from "./PongGame";
-import { CANVAS_HEIGHT, CANVAS_WIDTH, TARGET_FRAME_MS } from "./const";
-import { Button } from "@/components/ui/button";
-import { io } from "socket.io-client";
-import type { Socket } from "socket.io-client";
-import PongInformationBoard from "./PongInformationBoard";
-import { useTheme } from "next-themes";
 import { useUserMode } from "@/app/lib/hooks/useUserMode";
+import { Button } from "@/components/ui/button";
+import { useTheme } from "next-themes";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import { io } from "socket.io-client";
+import { PongGame } from "./PongGame";
+import PongInformationBoard from "./PongInformationBoard";
+import { CANVAS_HEIGHT, CANVAS_WIDTH, TARGET_FRAME_MS } from "./const";
 
 type setState<T> = T | ((prevState: T) => T);
 

--- a/frontend/app/pong/page.tsx
+++ b/frontend/app/pong/page.tsx
@@ -1,10 +1,8 @@
-import * as React from "react";
-
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { v4 } from "uuid";
 import JoinRoomForm from "./JoinRoomForm";
 import MatchButton from "./MatchButton";
-import { v4 } from "uuid";
 
 export default function Page() {
   const roomId = v4();

--- a/frontend/app/profile/layout.tsx
+++ b/frontend/app/profile/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { SidebarNav } from "@/app/ui/profile/sidebar-nav";
 import { Stack } from "@/app/ui/layout/stack";
+import { SidebarNav } from "@/app/ui/profile/sidebar-nav";
 import { Separator } from "@/components/ui/separator";
 import { usePathname } from "next/navigation";
 

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -25,15 +25,14 @@
 //  );
 //}
 
+import { getMessages, getRoom, getUser, getUsers } from "@/app/lib/actions";
 import { getCurrentUserId } from "@/app/lib/session";
-import { Separator } from "@/components/ui/separator";
-import { Sidebar } from "../sidebar";
-import { getRoom, getUsers, getUser } from "@/app/lib/actions";
-import MessageArea from "../message-area";
-import { notFound } from "next/navigation";
 import type { User } from "@/app/ui/user/card";
+import { Separator } from "@/components/ui/separator";
+import { notFound } from "next/navigation";
+import MessageArea from "../message-area";
 import type { UserOnRoom, UserWithRole } from "../sidebar";
-import { getMessages } from "@/app/lib/actions";
+import { Sidebar } from "../sidebar";
 
 type UserRole = {
   id: number;

--- a/frontend/app/room/create/page.tsx
+++ b/frontend/app/room/create/page.tsx
@@ -1,13 +1,6 @@
 // components
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import Form from "@/app/ui/room/create-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function CreateChatRoom() {
   return (

--- a/frontend/app/room/message-area.tsx
+++ b/frontend/app/room/message-area.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { Stack } from "@/app/ui/layout/stack";
-import { useEffect, useRef, useState } from "react";
-import { MessageGroup } from "@/app/ui/room/message-group";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import type { User } from "@/app/ui/user/card";
-import { MessageSkeleton } from "@/app/ui/room/skeleton";
 import { groupMessagesByUser, useScrollToBottom } from "@/app/ui/room/helper";
+import { MessageGroup } from "@/app/ui/room/message-group";
+import { MessageSkeleton } from "@/app/ui/room/skeleton";
+import type { User } from "@/app/ui/user/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { chatSocket as socket } from "@/socket";
+import { useEffect, useRef, useState } from "react";
 import * as z from "zod";
 import { Message } from "../ui/room/test-data";
 

--- a/frontend/app/room/page.tsx
+++ b/frontend/app/room/page.tsx
@@ -1,6 +1,5 @@
-import RoomCard from "@/app/ui/room/card";
-import type { Room } from "@/app/ui/room/card";
 import { getRooms } from "@/app/lib/actions";
+import RoomCard from "@/app/ui/room/card";
 
 export default async function RoomListPage() {
   const rooms = await getRooms();

--- a/frontend/app/room/sidebar-button.tsx
+++ b/frontend/app/room/sidebar-button.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { deleteRoomUser, updateRoomUser } from "@/app/lib/actions";
 import { SmallAvatarSkeleton } from "@/app/ui/room/skeleton";
+import type { User } from "@/app/ui/user/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -8,15 +11,10 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Stack } from "@/app/ui/layout/stack";
-import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
 import { chatSocket as socket } from "@/socket";
-import type { User } from "@/app/ui/user/card";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import type { UserOnRoom, UserWithRole } from "./sidebar";
-import { updateRoomUser, deleteRoomUser } from "@/app/lib/actions";
-import { redirect, RedirectType } from "next/navigation";
 
 function truncateString(str: string | undefined, num: number): string {
   if (!str) {

--- a/frontend/app/room/sidebar.tsx
+++ b/frontend/app/room/sidebar.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { toast } from "@/components/ui/use-toast";
 import { Stack } from "@/app/ui/layout/stack";
 import type { User } from "@/app/ui/user/card";
-import { SidebarButton } from "./sidebar-button";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { toast } from "@/components/ui/use-toast";
 import { chatSocket as socket } from "@/socket";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { SidebarButton } from "./sidebar-button";
 
 export type UserOnRoom = {
   id: number;

--- a/frontend/app/ui/login-form.tsx
+++ b/frontend/app/ui/login-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useFormState, useFormStatus } from "react-dom";
+import { authenticate } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { authenticate } from "@/app/lib/actions";
+import { useFormState, useFormStatus } from "react-dom";
 import { useAuthContext } from "../lib/client-auth";
 
 export default function LoginForm() {

--- a/frontend/app/ui/nav.tsx
+++ b/frontend/app/ui/nav.tsx
@@ -1,8 +1,8 @@
+import { signInAsTestUser, signOut } from "@/app/lib/actions";
+import { isLoggedIn } from "@/app/lib/session";
 import { ModeToggle } from "@/components/toggle-mode";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { signInAsTestUser, signOut } from "@/app/lib/actions";
-import { isLoggedIn } from "@/app/lib/session";
 
 function AuthorizedMenu() {
   return (

--- a/frontend/app/ui/profile/change-password-form.tsx
+++ b/frontend/app/ui/profile/change-password-form.tsx
@@ -4,10 +4,10 @@ import { updatePassword } from "@/app/lib/actions";
 import { Stack } from "@/app/ui/layout/stack";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/use-toast";
 import { useState } from "react";
 import { useFormState, useFormStatus } from "react-dom";
-import { Label } from "@/components/ui/label";
 
 function ErrorText({ text }: { text: string }) {
   return (

--- a/frontend/app/ui/profile/profile-form.tsx
+++ b/frontend/app/ui/profile/profile-form.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { Button } from "@/components/ui/button";
-import { Stack } from "@/app/ui/layout/stack";
 import { useAuthContext } from "@/app/lib/client-auth";
-import { ProfileItem } from "./profile-item-form";
+import { Stack } from "@/app/ui/layout/stack";
+import { Button } from "@/components/ui/button";
 import AvatarForm from "./avatar-form";
+import { ProfileItem } from "./profile-item-form";
 
 export default function ProfileForm() {
   const { currentUser } = useAuthContext();

--- a/frontend/app/ui/profile/sidebar-nav.tsx
+++ b/frontend/app/ui/profile/sidebar-nav.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
   items: {

--- a/frontend/app/ui/room/card.tsx
+++ b/frontend/app/ui/room/card.tsx
@@ -1,23 +1,19 @@
 "use client";
 
 import { useFormState } from "react-dom";
-import { redirect } from "next/navigation";
 
 // components
+import { joinRoom } from "@/app/lib/actions";
+import { deleteRoom, updateRoom } from "@/app/lib/client-actions";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-import { updateRoom, deleteRoom } from "@/app/lib/client-actions";
-import { joinRoom } from "@/app/lib/actions";
 
 type Room = { id: number; name?: string };
 

--- a/frontend/app/ui/room/create-form.tsx
+++ b/frontend/app/ui/room/create-form.tsx
@@ -3,9 +3,9 @@
 import { createRoom } from "@/app/lib/actions";
 
 // components
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 
 export default function RoomCreateForm() {
   return (

--- a/frontend/app/ui/user/card.tsx
+++ b/frontend/app/ui/user/card.tsx
@@ -1,23 +1,21 @@
 "use client";
 
-import { useFormState } from "react-dom";
 import { redirect, RedirectType } from "next/navigation";
+import { useFormState } from "react-dom";
 
 // components
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 
-import { updateUser, deleteUser } from "@/app/lib/actions";
+import { deleteUser, updateUser } from "@/app/lib/actions";
 
 export type User = { id: number; name?: string; email?: string };
 

--- a/frontend/app/ui/user/create-form.tsx
+++ b/frontend/app/ui/user/create-form.tsx
@@ -3,9 +3,9 @@
 import { createUser } from "@/app/lib/client-actions";
 
 // components
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 
 export default function UserCreateForm() {
   return (

--- a/frontend/app/user/[id]/page.tsx
+++ b/frontend/app/user/[id]/page.tsx
@@ -1,6 +1,5 @@
-import UserCard from "@/app/ui/user/card";
-import { cookies } from "next/headers";
 import { getUser } from "@/app/lib/actions";
+import UserCard from "@/app/ui/user/card";
 
 export default async function FindUser({
   params: { id },

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -1,5 +1,5 @@
-import UserCard from "@/app/ui/user/card";
 import { getUsers } from "@/app/lib/actions";
+import UserCard from "@/app/ui/user/card";
 
 export default async function UserListPage() {
   const users = await getUsers();

--- a/frontend/app/user/signup/page.tsx
+++ b/frontend/app/user/signup/page.tsx
@@ -1,13 +1,6 @@
 // components
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import Form from "@/app/ui/user/create-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function SignUp() {
   return (

--- a/frontend/components/theme-provider.tsx
+++ b/frontend/components/theme-provider.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ThemeProviderProps } from "next-themes/dist/types";
 

--- a/frontend/components/toggle-mode.tsx
+++ b/frontend/components/toggle-mode.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -78,9 +78,9 @@ CardFooter.displayName = "CardFooter";
 
 export {
   Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardDescription,
   CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 };

--- a/frontend/components/ui/checkbox.tsx
+++ b/frontend/components/ui/checkbox.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { Check } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/frontend/components/ui/context-menu.tsx
+++ b/frontend/components/ui/context-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -183,18 +183,18 @@ ContextMenuShortcut.displayName = "ContextMenuShortcut";
 
 export {
   ContextMenu,
-  ContextMenuTrigger,
-  ContextMenuContent,
-  ContextMenuItem,
   ContextMenuCheckboxItem,
-  ContextMenuRadioItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
-  ContextMenuGroup,
-  ContextMenuPortal,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuRadioGroup,
+  ContextMenuTrigger,
 };

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -183,18 +183,18 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuTrigger,
 };

--- a/frontend/components/ui/label.tsx
+++ b/frontend/components/ui/label.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/frontend/components/ui/scroll-area.tsx
+++ b/frontend/components/ui/scroll-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/frontend/components/ui/separator.tsx
+++ b/frontend/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -115,13 +115,13 @@ type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
-  type ToastProps,
-  type ToastActionElement,
-  ToastProvider,
-  ToastViewport,
   Toast,
-  ToastTitle,
-  ToastDescription,
-  ToastClose,
   ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  type ToastActionElement,
+  type ToastProps,
 };

--- a/frontend/components/ui/use-toast.ts
+++ b/frontend/components/ui/use-toast.ts
@@ -186,4 +186,4 @@ function useToast() {
   };
 }
 
-export { useToast, toast };
+export { toast, useToast };

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from "clsx";
+import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 import { isLoggedIn } from "@/app/lib/session";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 function isPathProtected(path: string) {
   if (path == "/user/signup") return false;


### PR DESCRIPTION
1. 不要なimportの削除
2. importをアルファベット順に並べる
をやりました。

VSCodeでは`Organize Imports` (`Shift + Option + O`)で実行できます。

https://zenn.dev/wakamsha/articles/prettier-plugin-organize-imports

プロジェクトのルートディレクトリにpackage.jsonを置くのは憚られたので、一旦手元のみでインストールして使いました。
- `npm install --save-dev prettier-plugin-organize-imports`
- `npx prettier --write frontend backend --plugin=prettier-plugin-organize-imports`