### PR TITLE
[frontend] Remove overflow-hidden from body（1行プルリク）

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={"overflow-hidden " + inter.className}>
+      <body className={inter.className}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
ヘッダー（ナビゲーション）やフッター（チャット画面のテキスト入力）がボヨボヨ動かないようにするためにoverflow-hiddenをつけていたが、コンテンツがはみ出したときに表示できないのが不便だったので削除する。むしろチャット画面はカスタマイズしようかなと。