### PR TITLE
友達一覧をユーザープロフィール画面に追加

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -76,7 +76,7 @@ export class UserController {
 
   /* Friend requests */
   @Get(':userId/friend')
-  @UseGuards(JwtAuthGuard, UserGuard)
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   async findAllFriends(@Param('userId', ParseIntPipe) userId: number) {
     const friends = await this.userService.findAllFriends(userId);

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -378,8 +378,7 @@ export async function unblockUser(blockedUserId: number) {
   }
 }
 
-export async function getFriends(): Promise<PublicUserEntity[]> {
-  const userId = await getCurrentUserId();
+export async function getFriends(userId: number): Promise<PublicUserEntity[]> {
   const res = await fetch(`${process.env.API_URL}/user/${userId}/friend`, {
     headers: {
       Authorization: "Bearer " + getAccessToken(),

--- a/frontend/app/ui/user/avatar.tsx
+++ b/frontend/app/ui/user/avatar.tsx
@@ -3,9 +3,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 export function Avatar({
   avatarURL,
   size,
+  alt,
 }: {
   avatarURL?: string;
   size: "small" | "medium" | "large";
+  alt?: string;
 }) {
   let sizeClass = "";
   switch (size) {
@@ -29,7 +31,7 @@ export function Avatar({
       <img
         className={`flex-none rounded-full object-cover ${sizeClass}`}
         src={avatarURL}
-        alt="avatar"
+        alt={alt}
       />
     );
   }

--- a/frontend/app/ui/user/friends.tsx
+++ b/frontend/app/ui/user/friends.tsx
@@ -1,4 +1,10 @@
 import { getFriends } from "@/app/lib/actions";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import Link from "next/link";
 import { Avatar } from "./avatar";
 import ProfileItem from "./profile-item";
@@ -7,18 +13,25 @@ export default async function Friends({ userId }: { userId: number }) {
   const friends = await getFriends(userId);
   return (
     <ProfileItem title="Friends">
-      <div className="flex gap-1">
-        {friends.length === 0 && <div>No friends</div>}
-        {friends.map((friend) => (
-          <Link href={`/user/${friend.id}`} key={friend.id}>
-            <Avatar
-              avatarURL={friend.avatarURL}
-              size="medium"
-              alt={friend.name}
-            />
-          </Link>
-        ))}
-      </div>
+      <TooltipProvider delayDuration={0}>
+        <div className="flex gap-1">
+          {friends.length === 0 && <div>No friends</div>}
+          {friends.map((friend) => (
+            <Tooltip key={friend.id}>
+              <TooltipTrigger>
+                <Link href={`/user/${friend.id}`} key={friend.id}>
+                  <Avatar
+                    avatarURL={friend.avatarURL}
+                    size="medium"
+                    alt={friend.name}
+                  />
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent>{friend.name}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </TooltipProvider>
     </ProfileItem>
   );
 }

--- a/frontend/app/ui/user/friends.tsx
+++ b/frontend/app/ui/user/friends.tsx
@@ -1,0 +1,24 @@
+import { getFriends } from "@/app/lib/actions";
+import Link from "next/link";
+import { Avatar } from "./avatar";
+import ProfileItem from "./profile-item";
+
+export default async function Friends({ userId }: { userId: number }) {
+  const friends = await getFriends(userId);
+  return (
+    <ProfileItem title="Friends">
+      <div className="flex gap-1">
+        {friends.length === 0 && <div>No friends</div>}
+        {friends.map((friend) => (
+          <Link href={`/user/${friend.id}`} key={friend.id}>
+            <Avatar
+              avatarURL={friend.avatarURL}
+              size="medium"
+              alt={friend.name}
+            />
+          </Link>
+        ))}
+      </div>
+    </ProfileItem>
+  );
+}

--- a/frontend/app/user/[id]/page.tsx
+++ b/frontend/app/user/[id]/page.tsx
@@ -4,6 +4,7 @@ import AcceptFriendButton from "@/app/ui/user/accept-friend-request-button";
 import AddFriendButton from "@/app/ui/user/add-friend-button";
 import { Avatar } from "@/app/ui/user/avatar";
 import CancelFriendRequestButton from "@/app/ui/user/cancel-friend-request-button";
+import Friends from "@/app/ui/user/friends";
 import MatchHistory from "@/app/ui/user/match-history";
 import MatchRequestButton from "@/app/ui/user/match-request-button";
 import RejectFriendButton from "@/app/ui/user/reject-friend-request-button";
@@ -18,12 +19,12 @@ export default async function FindUser({
   const userId = parseInt(id, 10);
   const user = await getUser(userId);
   const requests = await getFriendRequests();
-  const friends = await getFriends();
+  const currentUserId = await getCurrentUserId();
+  const myFriends = await getFriends(currentUserId);
   // check if any requesting contains userId
   const hasSentRequest = requests.requesting.some((r) => r.id === userId);
   const hasReceivedRequest = requests.requestedBy.some((r) => r.id === userId);
-  const isFriend = friends.some((f) => f.id == userId);
-  const currentUserId = await getCurrentUserId();
+  const isFriend = myFriends.some((f) => f.id == userId);
   const canAddFriend = !hasSentRequest && !hasReceivedRequest && !isFriend;
   // TODO: Must consider these situations
   // 1. Already friends
@@ -51,9 +52,9 @@ export default async function FindUser({
           <MatchRequestButton id={userId} />
         </>
       )}
+      <Friends userId={userId} />
       <Stats userId={userId} />
       <MatchHistory userId={userId} />
-      <div className="bg-secondary">Friends</div>
     </div>
   );
 }

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
+        "@radix-ui/react-tooltip": "^1.0.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "jose": "^5.1.3",
@@ -996,6 +997,40 @@
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1",
         "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz",
+      "integrity": "sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
         "@radix-ui/react-visually-hidden": "1.0.3"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "jose": "^5.1.3",


### PR DESCRIPTION
ユーザープロフィール画面にて友達を一覧表示するように実装しました。
<img width="982" alt="Screenshot 2023-12-22 at 15 19 17" src="https://github.com/usatie/pong/assets/7609060/ac930375-1d4d-4913-ab32-fed03aaf37dc">

## Tooltipについて
Shadcnで追加したTooltipを利用してユーザ名をホバーした時に表示しています。

https://ui.shadcn.com/docs/components/tooltip
https://www.radix-ui.com/primitives/docs/components/tooltip

<img width="235" alt="Screenshot 2023-12-22 at 15 19 27" src="https://github.com/usatie/pong/assets/7609060/88b9d1d5-be92-4f73-a84a-19c7f59f4471">

<img width="230" alt="Screenshot 2023-12-22 at 15 19 31" src="https://github.com/usatie/pong/assets/7609060/6cfa8b0d-9efc-4e92-bcff-287b7ceb4b18">

## 友達がいない人
<img width="970" alt="Screenshot 2023-12-22 at 15 22 58" src="https://github.com/usatie/pong/assets/7609060/cda4267d-0c03-4e84-8f00-5e96e2112acb">