### PR TITLE
[frontend] Add modal window for ban management

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,6 +14,8 @@ import { getMe } from "@/app/lib/actions";
 import { JwtPayload } from "@/app/lib/dtos";
 import Nav from "@/app/ui/nav";
 
+import { ModalProvider } from "@/app/lib/modal-provider";
+
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -50,6 +52,7 @@ export default async function RootLayout({
             </div>
             <Toaster />
           </AuthProvider>
+          <ModalProvider />
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -595,3 +595,41 @@ export async function twoFactorAuthenticate(
     return "Success";
   }
 }
+
+export async function banUser(roomId: number, userId: number) {
+  const res = await fetch(
+    `${process.env.API_URL}/room/${roomId}/bans/${userId}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer " + getAccessToken(),
+      },
+    },
+  );
+  if (!res.ok) {
+    console.error("banUser error: ", await res.json());
+    return "Error";
+  } else {
+    revalidatePath(`/room/${roomId}`);
+    return "Success";
+  }
+}
+
+export async function unbanUser(roomId: number, userId: number) {
+  const res = await fetch(
+    `${process.env.API_URL}/room/${roomId}/bans/${userId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: "Bearer " + getAccessToken(),
+      },
+    },
+  );
+  if (!res.ok) {
+    console.error("unbanUser error: ", await res.json());
+    return "Error";
+  } else {
+    revalidatePath(`/room/${roomId}`);
+    return "Success";
+  }
+}

--- a/frontend/app/lib/hooks/use-modal-store.ts
+++ b/frontend/app/lib/hooks/use-modal-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+type ModalType = "ban";
+
+interface ModalData {
+  roomId?: number;
+  roomName?: string;
+  me?: UserOnRoomEntity;
+  users?: UserOnRoomEntity[];
+}
+
+interface ModalStore {
+  type: ModalType | null;
+  data: ModalData;
+  isOpen: boolean;
+  onOpen: (type: ModalType, data?: ModalData) => void;
+  onClose: () => void;
+}
+
+export const useModal = create<ModalStore>((set) => ({
+  type: null,
+  data: {},
+  isOpen: false,
+  onOpen: (type, data = {}) => set({ isOpen: true, type, data }),
+  onClose: () => set({ type: null, isOpen: false }),
+}));

--- a/frontend/app/lib/hooks/use-modal-store.ts
+++ b/frontend/app/lib/hooks/use-modal-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { UserOnRoomEntity, PublicUserEntity } from "@/app/lib/dtos";
 
 type ModalType = "ban";
 
@@ -6,7 +7,7 @@ interface ModalData {
   roomId?: number;
   roomName?: string;
   me?: UserOnRoomEntity;
-  users?: UserOnRoomEntity[];
+  allUsers?: PublicUserEntity[];
 }
 
 interface ModalStore {

--- a/frontend/app/lib/modal-provider.tsx
+++ b/frontend/app/lib/modal-provider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BanModal } from "@/app/ui/room/ban-modal";
+
+export const ModalProvider = () => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <>
+      <BanModal />
+    </>
+  );
+};

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getMessages, getRoom } from "@/app/lib/actions";
+import { getMessages, getRoom, getUsers } from "@/app/lib/actions";
 import { Separator } from "@/components/ui/separator";
 import MessageArea from "./message-area";
 import { Sidebar } from "./sidebar";
@@ -12,10 +12,16 @@ export default async function Page({
   const room = await getRoom(roomId);
   const messages = await getMessages(roomId);
   console.log(messages);
+  const allUsers = await getUsers();
   return (
     <>
       <div className="overflow-auto flex-grow flex gap-4 pb-4">
-        <Sidebar roomId={roomId} roomName={room.name} users={room.users} />
+        <Sidebar
+          roomId={roomId}
+          roomName={room.name}
+          users={room.users}
+          allUsers={allUsers}
+        />
         <Separator orientation="vertical" />
         <MessageArea roomId={roomId} messages={messages} />
       </div>

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({
   return (
     <>
       <div className="overflow-auto flex-grow flex gap-4 pb-4">
-        <Sidebar roomId={roomId} users={room.users} />
+        <Sidebar roomId={roomId} roomName={room.name} users={room.users} />
         <Separator orientation="vertical" />
         <MessageArea roomId={roomId} messages={messages} />
       </div>

--- a/frontend/app/room/[id]/sidebar-menu.tsx
+++ b/frontend/app/room/[id]/sidebar-menu.tsx
@@ -1,0 +1,56 @@
+"use clinet";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown, UserPlus, Settings, Ban, LogOut } from "lucide-react";
+import type { UserOnRoomEntity } from "@/app/lib/dtos";
+
+export const SidebarMenu = ({
+  roomId,
+  roomName,
+  me,
+  users,
+}: {
+  roomId: number;
+  roomName: string;
+  me: UserOnRoomEntity;
+  users: UserOnRoomEntity[];
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="focus:outline-none" asChild>
+        <button className="w-full text-md font-semibold px-3 flex items-center h-10 border-meutral-200 dark:border-neutral-800 border-b-2 mb-2 hover:bg-zinc-700/10 dark:hover:bg-zinc-700/50 transition">
+          {roomName}
+          <ChevronDown className="h-5 w-5 ml-auto" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-full text-xs font-medium text-black dark:text-neutral-400 space-y-[2px]">
+        <DropdownMenuItem className="text-indigo-600 dark:text-indigo-400 px-3 py-2 text-sm cursor-pointer">
+          Add User
+          <UserPlus className="h-4 w-4 ml-auto" />
+        </DropdownMenuItem>
+        {(me.role === "OWNER" || me.role === "ADMINISTRATOR") && (
+          <DropdownMenuItem className="px-3 py-2 text-sm cursor-pointer">
+            Setting
+            <Settings className="h-4 w-4 ml-auto" />
+          </DropdownMenuItem>
+        )}
+        {(me.role === "OWNER" || me.role === "ADMINISTRATOR") && (
+          <DropdownMenuItem className="text-rose-500 px-3 py-2 text-sm cursor-pointer">
+            Ban User
+            <Ban className="h-4 w-4 ml-auto" />
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem className="text-rose-500 px-3 py-2 text-sm cursor-pointer">
+          Leave
+          <LogOut className="h-4 w-4 ml-auto" />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/frontend/app/room/[id]/sidebar-menu.tsx
+++ b/frontend/app/room/[id]/sidebar-menu.tsx
@@ -8,9 +8,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown, UserPlus, Settings, Ban, LogOut } from "lucide-react";
-import type { PublicUserEntity } from "@/app/lib/dtos";
 import { useModal } from "@/app/lib/hooks/use-modal-store";
 import { BanModal } from "@/app/ui/room/ban-modal";
+import { UserOnRoomEntity, PublicUserEntity } from "@/app/lib/dtos";
 
 export const SidebarMenu = ({
   roomId,

--- a/frontend/app/room/[id]/sidebar-menu.tsx
+++ b/frontend/app/room/[id]/sidebar-menu.tsx
@@ -1,4 +1,4 @@
-"use clinet";
+"use client";
 
 import {
   DropdownMenu,
@@ -8,19 +8,23 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown, UserPlus, Settings, Ban, LogOut } from "lucide-react";
-import type { UserOnRoomEntity } from "@/app/lib/dtos";
+import type { PublicUserEntity } from "@/app/lib/dtos";
+import { useModal } from "@/app/lib/hooks/use-modal-store";
+import { BanModal } from "@/app/ui/room/ban-modal";
 
 export const SidebarMenu = ({
   roomId,
   roomName,
   me,
-  users,
+  allUsers,
 }: {
   roomId: number;
   roomName: string;
   me: UserOnRoomEntity;
-  users: UserOnRoomEntity[];
+  allUsers: PublicUserEntity[];
 }) => {
+  const { onOpen } = useModal();
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="focus:outline-none" asChild>
@@ -41,9 +45,13 @@ export const SidebarMenu = ({
           </DropdownMenuItem>
         )}
         {(me.role === "OWNER" || me.role === "ADMINISTRATOR") && (
-          <DropdownMenuItem className="text-rose-500 px-3 py-2 text-sm cursor-pointer">
+          <DropdownMenuItem
+            onClick={() => onOpen("ban", { roomId, roomName, me, allUsers })}
+            className="text-rose-500 px-3 py-2 text-sm cursor-pointer"
+          >
             Ban User
             <Ban className="h-4 w-4 ml-auto" />
+            <BanModal />
           </DropdownMenuItem>
         )}
         <DropdownMenuItem className="text-rose-500 px-3 py-2 text-sm cursor-pointer">

--- a/frontend/app/room/[id]/sidebar.tsx
+++ b/frontend/app/room/[id]/sidebar.tsx
@@ -2,12 +2,15 @@ import type { UserOnRoomEntity } from "@/app/lib/dtos";
 import { getCurrentUserId } from "@/app/lib/session";
 import { Stack } from "@/components/layout/stack";
 import SidebarItem from "./sidebar-item";
+import { SidebarMenu } from "./sidebar-menu";
 
 export async function Sidebar({
   roomId,
+  roomName,
   users,
 }: {
   roomId: number;
+  roomName: string;
   users: UserOnRoomEntity[];
 }) {
   const currentUserId = await getCurrentUserId();
@@ -17,6 +20,7 @@ export async function Sidebar({
   }
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4">
+      <SidebarMenu roomId={roomId} roomName={roomName} me={me} users={users} />
       <Stack space="space-y-2">
         {users.map((user) => (
           <SidebarItem roomId={roomId} user={user} me={me} key={user.userId} />

--- a/frontend/app/room/[id]/sidebar.tsx
+++ b/frontend/app/room/[id]/sidebar.tsx
@@ -1,4 +1,4 @@
-import type { UserOnRoomEntity } from "@/app/lib/dtos";
+import type { UserOnRoomEntity, PublicUserEntity } from "@/app/lib/dtos";
 import { getCurrentUserId } from "@/app/lib/session";
 import { Stack } from "@/components/layout/stack";
 import SidebarItem from "./sidebar-item";
@@ -8,10 +8,12 @@ export async function Sidebar({
   roomId,
   roomName,
   users,
+  allUsers,
 }: {
   roomId: number;
   roomName: string;
   users: UserOnRoomEntity[];
+  allUsers: PublicUserEntity[];
 }) {
   const currentUserId = await getCurrentUserId();
   const me = users.find((u) => u.userId === currentUserId);
@@ -20,7 +22,12 @@ export async function Sidebar({
   }
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4">
-      <SidebarMenu roomId={roomId} roomName={roomName} me={me} users={users} />
+      <SidebarMenu
+        roomId={roomId}
+        roomName={roomName}
+        me={me}
+        allUsers={allUsers}
+      />
       <Stack space="space-y-2">
         {users.map((user) => (
           <SidebarItem roomId={roomId} user={user} me={me} key={user.userId} />

--- a/frontend/app/ui/room/ban-modal.tsx
+++ b/frontend/app/ui/room/ban-modal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useModal } from "@/app/lib/hooks/use-modal-store";
+import { Avatar } from "@/app/ui/user/avatar";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ChevronDown, UserPlus, Settings, Ban, LogOut } from "lucide-react";
+import { banUser } from "@/app/lib/actions";
+
+export const BanModal = () => {
+  const router = useRouter();
+  const { onOpen, isOpen, onClose, type, data } = useModal();
+
+  const isModalOpen = isOpen && type === "ban";
+  console.log(data);
+  const { roomId, roomName, me, allUsers } = { ...data };
+  console.log(roomId, roomName, me, allUsers);
+
+  const onBan = async (userId: number) => {
+    console.log("onBan");
+    banUser(roomId, userId);
+    // ban action
+  };
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={onClose}>
+      <DialogContent className="bg-white text-black overflow-hidden">
+        <DialogHeader className="pt-8 px-6">
+          <DialogTitle className="text-2x1 text-center font-bold">
+            Manage Ban users
+          </DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="mt-8 max-h-[420px] pr-6">
+          {allUsers?.map((user) => (
+            <div
+              key={user.id}
+              onClick={() => onBan(user.id)}
+              className="flex items-center gap-x-2 mb-6"
+            >
+              <Avatar avatarURL={user.avatarURL} />
+              <div className="flex flex-col gap-y-1">
+                <div className="text-xs font-semibold flex items-center gap-x-1">
+                  {user.name}
+                </div>
+              </div>
+              <button className="text-rose-500 ml-auto">
+                <Ban className="h-4 w-4 ml-2" />
+                BAN
+              </button>
+            </div>
+          ))}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/app/ui/room/ban-modal.tsx
+++ b/frontend/app/ui/room/ban-modal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -26,6 +25,9 @@ export const BanModal = () => {
 
   const onBan = async (userId: number) => {
     console.log("onBan");
+    if (!roomId) {
+      throw new Error("not found room");
+    }
     banUser(roomId, userId);
     // ban action
   };
@@ -45,7 +47,7 @@ export const BanModal = () => {
               onClick={() => onBan(user.id)}
               className="flex items-center gap-x-2 mb-6"
             >
-              <Avatar avatarURL={user.avatarURL} />
+              <Avatar avatarURL={user.avatarURL} size="medium" />
               <div className="flex flex-col gap-y-1">
                 <div className="text-xs font-semibold flex items-center gap-x-1">
                   {user.name}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-context-menu": "^2.1.5",
+        "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-scroll-area": "^1.0.5",
@@ -31,7 +32,8 @@
         "tailwind-merge": "^2.1.0",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^9.0.1",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zustand": "^4.4.7"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -566,6 +568,42 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5388,6 +5426,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5677,6 +5723,33 @@
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
+      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-context-menu": "^2.1.5",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-scroll-area": "^1.0.5",
@@ -32,7 +33,8 @@
     "tailwind-merge": "^2.1.0",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^9.0.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
roomにドロップダウンメニューを追加
BANの管理をするモーダルウィンドウを追加(BANが出来るだけでUNBANやBAN中かどうかの表示はまだ実装してません)
(Leave, setting, Add Userなどはハリボテ)
<img width="1440" alt="スクリーンショット 2024-01-03 0 29 56" src="https://github.com/usatie/pong/assets/90199432/583cccf7-2f2d-43b5-94ec-714b89640655">
<img width="1440" alt="スクリーンショット 2024-01-03 0 30 06" src="https://github.com/usatie/pong/assets/90199432/f05d891a-769a-4740-aa74-08d96245a93e">
