### PR TITLE
[backend] Processing blocks and unblocks in real-time

### DIFF
--- a/backend/src/chat/chat.controller.spec.ts
+++ b/backend/src/chat/chat.controller.spec.ts
@@ -1,6 +1,7 @@
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from 'src/auth/auth.service';
+import { UserService } from 'src/user/user.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
@@ -11,7 +12,13 @@ describe('ChatController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChatController],
-      providers: [ChatService, PrismaService, AuthService, JwtService],
+      providers: [
+        ChatService,
+        PrismaService,
+        AuthService,
+        UserService,
+        JwtService,
+      ],
     }).compile();
 
     controller = module.get<ChatController>(ChatController);

--- a/backend/src/chat/chat.controller.spec.ts
+++ b/backend/src/chat/chat.controller.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from 'src/auth/auth.service';
@@ -18,6 +19,7 @@ describe('ChatController', () => {
         AuthService,
         UserService,
         JwtService,
+        EventEmitter2,
       ],
     }).compile();
 

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -191,8 +191,17 @@ export class ChatGateway {
 
     // TODO: exclude blocked users
 
+    //block APIが呼ばれて成功した時user.controller.tsからchat.gateway.tsの（ブロックされた側の各ユーザーの）block roomにjoinするようにする
+    //unblock APIが呼ばれて成功した時user.controller.tsからchat.gateway.tsのblock roomからleaveするようにする
+    //block roomにjoinしているユーザーにはメッセージを送らないようにする
+    //
+    //もしくはmessageを送る前に送信者をblockしているユーザーを取得して、そのユーザーIDからsocket idを取得して送らないようにする
+    //こちらの場合はblockされた側が自分のことをblockしているユーザーを取得できるようにAPIを作る必要がある
+
     // Send message to the room
-    const room = this.server.to(data.roomId.toString());
+    const room = this.server
+      .to(data.roomId.toString())
+      .except('block' + data.userId);
     room.emit(
       'message',
       new MessageEntity(data, this.chatService.getUser(client)),

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -73,50 +73,6 @@ export class ChatGateway {
     }
   }
 
-  @SubscribeMessage('block')
-  handleBlockUser(
-    @MessageBody() userId: number,
-    @ConnectedSocket() client: Socket,
-  ) {
-    const blockerId = this.getValueToKey(this.userMap, client.id);
-    if (
-      this.blockMap.has(userId) &&
-      this.blockMap.get(userId).includes(blockerId)
-    ) {
-      this.logger.error('Already blocked');
-    } else {
-      this.userService.block(blockerId, userId);
-      this.logger.log(`block user: ${userId}(${client.id})`);
-      if (this.blockMap.has(userId)) {
-        this.blockMap.get(userId).push(blockerId);
-      } else {
-        this.blockMap.set(userId, [blockerId]);
-      }
-      client.join('block' + userId);
-    }
-  }
-
-  @SubscribeMessage('unblock')
-  handleUnblockUser(
-    @MessageBody() userId: number,
-    @ConnectedSocket() client: Socket,
-  ) {
-    const unblockerId = this.getValueToKey(this.userMap, client.id);
-    if (this.blockMap.has(userId)) {
-      this.userService.unblock(unblockerId, userId);
-      const index = this.blockMap.get(userId).indexOf(unblockerId);
-      if (index !== -1) {
-        this.blockMap.get(userId).splice(index, 1);
-        this.logger.log(`unblock user: ${userId}(${client.id})`);
-        client.leave('block' + userId);
-      } else {
-        this.logger.error(`User ${userId} has not been blocked`);
-      }
-    } else {
-      this.logger.error(`User ${userId} has not been blocked`);
-    }
-  }
-
   @SubscribeMessage('joinDM')
   async handleJoinUser(
     @MessageBody() userId: number,

--- a/backend/src/chat/chat.service.spec.ts
+++ b/backend/src/chat/chat.service.spec.ts
@@ -1,6 +1,7 @@
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from 'src/auth/auth.service';
+import { UserService } from 'src/user/user.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ChatService } from './chat.service';
 
@@ -9,7 +10,13 @@ describe('ChatService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ChatService, PrismaService, AuthService, JwtService],
+      providers: [
+        ChatService,
+        PrismaService,
+        AuthService,
+        UserService,
+        JwtService,
+      ],
     }).compile();
 
     service = module.get<ChatService>(ChatService);

--- a/backend/src/chat/chat.service.spec.ts
+++ b/backend/src/chat/chat.service.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from 'src/auth/auth.service';
@@ -16,6 +17,7 @@ describe('ChatService', () => {
         AuthService,
         UserService,
         JwtService,
+        EventEmitter2,
       ],
     }).compile();
 

--- a/backend/src/common/events/block.event.ts
+++ b/backend/src/common/events/block.event.ts
@@ -1,0 +1,4 @@
+export class BlockEvent {
+  blockerId: number;
+  blockedId: number;
+}

--- a/backend/src/common/events/unblock.event.ts
+++ b/backend/src/common/events/unblock.event.ts
@@ -1,0 +1,4 @@
+export class UnblockEvent {
+  unblockerId: number;
+  unblockedId: number;
+}

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -101,8 +101,8 @@ export class RoomController {
   @UseGuards(MemberGuard)
   @ApiBearerAuth()
   @ApiOkResponse()
-  getMessages(@Member() member: UserOnRoomEntity) {
-    return this.roomService.findAllMessages(member.roomId);
+  getMessages(@Member() member: UserOnRoomEntity, @CurrentUser() user: User) {
+    return this.roomService.findAllMessages(member.roomId, user);
   }
 
   // UserOnRoom CRUD

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -109,9 +109,18 @@ export class RoomService {
     });
   }
 
-  findAllMessages(roomId: number) {
+  findAllMessages(roomId: number, user: User) {
     return this.prisma.message.findMany({
-      where: { roomId: roomId },
+      where: {
+        roomId: roomId,
+        user: {
+          blockedBy: {
+            none: {
+              id: user.id,
+            },
+          },
+        },
+      },
       select: {
         content: true,
         roomId: true,
@@ -123,6 +132,9 @@ export class RoomService {
             avatarURL: true,
           },
         },
+      },
+      orderBy: {
+        createdAt: 'asc',
       },
     });
   }

--- a/backend/src/user/user.controller.spec.ts
+++ b/backend/src/user/user.controller.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UserController } from './user.controller';
@@ -9,7 +10,7 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService, PrismaService],
+      providers: [UserService, PrismaService, EventEmitter2],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UserService } from './user.service';
@@ -7,7 +8,7 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService, PrismaService],
+      providers: [UserService, PrismaService, EventEmitter2],
     }).compile();
 
     service = module.get<UserService>(UserService);

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -333,7 +333,6 @@ describe('ChatGateway and ChatController (e2e)', () => {
 
     let ctx3, ctx4: Promise<void>;
     it('setup promises to recv messages from blockedUser1 after unblocking', async () => {
-      await new Promise((r) => setTimeout(r, 1000));
       ctx3 = new Promise<void>((resolve) => {
         ws1.on('message', (data) => {
           const expected: MessageEntity = {
@@ -392,7 +391,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
       await ctx4;
     });
 
-    it('user1 should get all messages in the room', async () => {
+    it('user1 should get all messages except from blockedUser2 in the room', async () => {
       const res = await app
         .getMessagesInRoom(room.id, user1.accessToken)
         .expect(200);

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -431,6 +431,66 @@ describe('ChatGateway and ChatController (e2e)', () => {
     it('blockedUser1 receives ACK', async () => {
       await ctx8;
     });
+
+    it('user1 should get all messages in the room', async () => {
+      const res = await app
+        .getMessagesInRoom(room.id, user1.accessToken)
+        .expect(200);
+      const messages = res.body;
+      expect(messages).toHaveLength(5);
+      expect(messages).toEqual([
+        {
+          user: {
+            id: user1.id,
+            name: user1.name,
+            avatarURL: user1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: user2.id,
+            name: user2.name,
+            avatarURL: user2.avatarURL,
+          },
+          roomId: room.id,
+          content: 'ACK: hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: blockedUser1.id,
+            name: blockedUser1.name,
+            avatarURL: blockedUser1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: blockedUser1.id,
+            name: blockedUser1.name,
+            avatarURL: blockedUser1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: user1.id,
+            name: user1.name,
+            avatarURL: user1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'ACK: hello',
+          createdAt: expect.any(String),
+        },
+      ]);
+    });
   });
 
   /*

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -240,35 +240,6 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ]);
     });
 
-    let ctx3, ctx4: Promise<void>;
-    it('setup promises to not recv messages from blockedUser1', async () => {
-      await new Promise((r) => setTimeout(r, 1000));
-      ctx3 = new Promise<void>((resolve) => {
-        ws1.on('message', (data) => {
-          console.error(data);
-          throw new Error(
-            'User1 should not receive any message from blockedUser1',
-          );
-        });
-        setTimeout(() => {
-          ws1.off('message');
-          resolve();
-        }, 3000);
-      });
-      ctx4 = new Promise<void>((resolve) => {
-        ws2.on('message', (data) => {
-          console.error(data);
-          throw new Error(
-            'User2 should not receive any message from blockedUser1',
-          );
-        });
-        setTimeout(() => {
-          ws2.off('message');
-          resolve();
-        }, 3000);
-      });
-    });
-
     it('blockedUser1 sends message', () => {
       const helloMessage = {
         userId: blockedUser1.id,
@@ -278,9 +249,18 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ws3.emit('message', helloMessage);
     });
 
-    it('user1 and user2 should not receive message from blockedUser1', async () => {
-      await ctx3;
-      await ctx4;
+    it('user1 and user2 should not receive message from blockedUser1', (done) => {
+      const mockMessage = jest.fn();
+      const mockMessage2 = jest.fn();
+      ws1.on('message', mockMessage);
+      ws2.on('message', mockMessage2);
+      setTimeout(() => {
+        expect(mockMessage).not.toBeCalled();
+        expect(mockMessage2).not.toBeCalled();
+        ws1.off('message');
+        ws2.off('message');
+        done();
+      }, 3000);
     });
 
     it('user1 and user2 block blockedUser2', async () => {
@@ -292,35 +272,6 @@ describe('ChatGateway and ChatController (e2e)', () => {
         .expect(200);
     });
 
-    let ctx5, ctx6: Promise<void>;
-    it('setup promises to not recv messages from blockedUser2', async () => {
-      await new Promise((r) => setTimeout(r, 1000));
-      ctx5 = new Promise<void>((resolve) => {
-        ws1.on('message', (data) => {
-          console.error(data);
-          throw new Error(
-            'User1 should not receive any message from blockedUser2',
-          );
-        });
-        setTimeout(() => {
-          ws1.off('message');
-          resolve();
-        }, 3000);
-      });
-      ctx6 = new Promise<void>((resolve) => {
-        ws2.on('message', (data) => {
-          console.error(data);
-          throw new Error(
-            'User2 should not receive any message from blockedUser2',
-          );
-        });
-        setTimeout(() => {
-          ws2.off('message');
-          resolve();
-        }, 3000);
-      });
-    });
-
     it('blockedUser2 sends message', () => {
       const helloMessage = {
         userId: blockedUser2.id,
@@ -330,9 +281,18 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ws4.emit('message', helloMessage);
     });
 
-    it('user1 and user2 should not receive message from blockedUser2', async () => {
-      await ctx5;
-      await ctx6;
+    it('user1 and user2 should not receive message from blockedUser2', (done) => {
+      const mockMessage = jest.fn();
+      const mockMessage2 = jest.fn();
+      ws1.on('message', mockMessage);
+      ws2.on('message', mockMessage2);
+      setTimeout(() => {
+        expect(mockMessage).not.toBeCalled();
+        expect(mockMessage2).not.toBeCalled();
+        ws1.off('message');
+        ws2.off('message');
+        done();
+      }, 3000);
     });
 
     it('user1 should get all messages except from blockedUser1 and blockedUser2 in the room', async () => {
@@ -371,10 +331,10 @@ describe('ChatGateway and ChatController (e2e)', () => {
         .expect(200);
     });
 
-    let ctx7, ctx8: Promise<void>;
+    let ctx3, ctx4: Promise<void>;
     it('setup promises to recv messages from blockedUser1 after unblocking', async () => {
       await new Promise((r) => setTimeout(r, 1000));
-      ctx7 = new Promise<void>((resolve) => {
+      ctx3 = new Promise<void>((resolve) => {
         ws1.on('message', (data) => {
           const expected: MessageEntity = {
             user: {
@@ -396,7 +356,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
           resolve();
         });
       });
-      ctx8 = new Promise<void>((resolve) => {
+      ctx4 = new Promise<void>((resolve) => {
         ws3.on('message', (data) => {
           if (data.user.id === blockedUser1.id) return;
           const expected: MessageEntity = {
@@ -425,11 +385,11 @@ describe('ChatGateway and ChatController (e2e)', () => {
     });
 
     it('user1 receives messages and send ACK', async () => {
-      await ctx7;
+      await ctx3;
     });
 
     it('blockedUser1 receives ACK', async () => {
-      await ctx8;
+      await ctx4;
     });
 
     it('user1 should get all messages in the room', async () => {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -210,6 +210,36 @@ describe('ChatGateway and ChatController (e2e)', () => {
       await ctx2;
     });
 
+    it('user1 should get all messages in the room', async () => {
+      const res = await app
+        .getMessagesInRoom(room.id, user1.accessToken)
+        .expect(200);
+      const messages = res.body;
+      expect(messages).toHaveLength(2);
+      expect(messages).toEqual([
+        {
+          user: {
+            id: user1.id,
+            name: user1.name,
+            avatarURL: user1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: user2.id,
+            name: user2.name,
+            avatarURL: user2.avatarURL,
+          },
+          roomId: room.id,
+          content: 'ACK: hello',
+          createdAt: expect.any(String),
+        },
+      ]);
+    });
+
     let ctx3, ctx4: Promise<void>;
     it('setup promises to not recv messages from blockedUser1', async () => {
       await new Promise((r) => setTimeout(r, 1000));
@@ -305,7 +335,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
       await ctx6;
     });
 
-    it('user1 should get all messages in the room', async () => {
+    it('user1 should get all messages except from blockedUser1 and blockedUser2 in the room', async () => {
       const res = await app
         .getMessagesInRoom(room.id, user1.accessToken)
         .expect(200);


### PR DESCRIPTION
[backend]
 - blockしているユーザーからのメッセージを受け取らないことを確認するテストを追加しました。
 - unblockしたユーザーからのメッセージを受け取れることを確認するテストを追加しました。
 - block・unblockのリアルタイム処理を追加しました。
 - GET /room/:roomId/messagesでブロック中のユーザーからのメッセージを取得しないように変更しました。
  block中にリロードするとblockしたユーザーのメッセージが全て見えなくなりunblockすると全て見える仕様です。
  
  追加したテスト
<img width="852" alt="スクリーンショット 2024-01-11 19 06 06" src="https://github.com/usatie/pong/assets/90199432/a2a3dfaa-c64d-4cc2-9860-2cd7aa9a7a6a">

|blocker|blocked|
|---|---|
|<img width="1440" alt="スクリーンショット 2024-01-11 19 19 22" src="https://github.com/usatie/pong/assets/90199432/c5de2348-0993-4091-ae67-6ee690135d8e">|<img width="1440" alt="スクリーンショット 2024-01-11 19 19 28" src="https://github.com/usatie/pong/assets/90199432/c62af4b2-1a38-4491-ae51-a861bc03cb73">

|block時リロード|unblock時リロード|
|---|---|
|<img width="1440" alt="スクリーンショット 2024-01-11 19 22 40" src="https://github.com/usatie/pong/assets/90199432/f156163c-1601-4851-8004-cab0210501d6">|<img width="1440" alt="スクリーンショット 2024-01-11 19 22 05" src="https://github.com/usatie/pong/assets/90199432/79b84149-0a11-4b32-8cc6-19d8afb7b3a3">





