### PR TITLE
[backend] Fix kick user from room

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -77,7 +77,6 @@ export class ChatService {
     const client = this.clients.get(event.userId);
     if (client) {
       client.leave(event.roomId.toString());
-      console.log('leave success');
     }
   }
 

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -7,6 +7,7 @@ import { AuthService } from 'src/auth/auth.service';
 import { UserService } from 'src/user/user.service';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
+import { RoomLeftEvent } from 'src/common/events/room-left.event';
 import { BlockEvent } from 'src/common/events/block.event';
 import { UnblockEvent } from 'src/common/events/unblock.event';
 import { Logger } from '@nestjs/common';
@@ -71,10 +72,12 @@ export class ChatService {
     await this.addUserToRoom(event.roomId, event.userId);
   }
 
-  removeUserFromRoom(roomId: number, user: User) {
-    const client = this.clients.get(user.id);
+  @OnEvent('room.leave', { async: true })
+  async removeUserFromRoom(event: RoomLeftEvent) {
+    const client = this.clients.get(event.userId);
     if (client) {
-      client.leave(roomId.toString());
+      client.leave(event.roomId.toString());
+      console.log('leave success');
     }
   }
 

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -554,6 +554,25 @@ describe('ChatGateway and ChatController (e2e)', () => {
         },
       ]);
     });
+
+    it('user1 sends message', () => {
+      const helloMessage = {
+        userId: user1.id,
+        roomId: room.id,
+        content: 'hello',
+      };
+      ws1.emit('message', helloMessage);
+    });
+
+    it('kickUser1 should not receive message from user1', (done) => {
+      const mockMessage = jest.fn();
+      ws5.on('message', mockMessage);
+      setTimeout(() => {
+        expect(mockMessage).not.toBeCalled();
+        ws5.off('message');
+        done();
+      }, 3000);
+    });
   });
 
   /*

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -466,6 +466,12 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ]);
     });
 
+    it('user1 unblocks blockedUser2', async () => {
+      await app
+        .unblockUser(user1.id, blockedUser2.id, user1.accessToken)
+        .expect(200);
+    });
+
     it('user1 kicks kickedUser1', async () => {
       await app
         .kickFromRoom(room.id, kickedUser1.id, user1.accessToken)
@@ -495,12 +501,12 @@ describe('ChatGateway and ChatController (e2e)', () => {
       }, 3000);
     });
 
-    it('user1 should get all messages except from blockedUser2 in the room', async () => {
+    it('user1 should get all messages except from kickedUser1 in the room', async () => {
       const res = await app
         .getMessagesInRoom(room.id, user1.accessToken)
         .expect(200);
       const messages = res.body;
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(6);
       expect(messages).toEqual([
         {
           user: {
@@ -527,6 +533,16 @@ describe('ChatGateway and ChatController (e2e)', () => {
             id: blockedUser1.id,
             name: blockedUser1.name,
             avatarURL: blockedUser1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: blockedUser2.id,
+            name: blockedUser2.name,
+            avatarURL: blockedUser2.avatarURL,
           },
           roomId: room.id,
           content: 'hello',

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -564,7 +564,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ws1.emit('message', helloMessage);
     });
 
-    it('kickUser1 should not receive message from user1', (done) => {
+    it('kickedUser1 should not receive message from user1', (done) => {
       const mockMessage = jest.fn();
       ws5.on('message', mockMessage);
       setTimeout(() => {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -21,7 +21,8 @@ describe('ChatGateway and ChatController (e2e)', () => {
   let ws2: Socket; // Client socket 2
   let ws3: Socket; // Client socket 3
   let ws4: Socket; // Client socket 4
-  let user1, user2, blockedUser1, blockedUser2;
+  let ws5: Socket; // Client socket 5
+  let user1, user2, blockedUser1, blockedUser2, kickedUser1;
 
   beforeAll(async () => {
     //app = await initializeApp();
@@ -48,10 +49,16 @@ describe('ChatGateway and ChatController (e2e)', () => {
       email: 'blocked2@test.com',
       password: 'test-password',
     };
+    const dto5 = {
+      name: 'kicked-user1',
+      email: 'kicked1@test.com',
+      password: 'test-password',
+    };
     user1 = await app.createAndLoginUser(dto1);
     user2 = await app.createAndLoginUser(dto2);
     blockedUser1 = await app.createAndLoginUser(dto3);
     blockedUser2 = await app.createAndLoginUser(dto4);
+    kickedUser1 = await app.createAndLoginUser(dto5);
     await app
       .blockUser(user1.id, blockedUser1.id, user1.accessToken)
       .expect(200);
@@ -65,11 +72,13 @@ describe('ChatGateway and ChatController (e2e)', () => {
     await app.deleteUser(user2.id, user2.accessToken).expect(204);
     await app.deleteUser(blockedUser1.id, blockedUser1.accessToken).expect(204);
     await app.deleteUser(blockedUser2.id, blockedUser2.accessToken).expect(204);
+    await app.deleteUser(kickedUser1.id, kickedUser1.accessToken).expect(204);
     await app.close();
     ws1.close();
     ws2.close();
     ws3.close();
     ws4.close();
+    ws5.close();
   });
 
   const connect = (ws: Socket) => {
@@ -122,16 +131,21 @@ describe('ChatGateway and ChatController (e2e)', () => {
       ws4 = io('ws://localhost:3000/chat', {
         extraHeaders: { cookie: 'token=' + blockedUser2.accessToken },
       });
+      ws5 = io('ws://localhost:3000/chat', {
+        extraHeaders: { cookie: 'token=' + kickedUser1.accessToken },
+      });
       expect(ws1).toBeDefined();
       expect(ws2).toBeDefined();
       expect(ws3).toBeDefined();
       expect(ws4).toBeDefined();
+      expect(ws5).toBeDefined();
 
       // Wait for connection
       await connect(ws1);
       await connect(ws2);
       await connect(ws3);
       await connect(ws4);
+      await connect(ws5);
     });
 
     // // Enter room by API call
@@ -146,6 +160,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
       await app.enterRoom(room.id, user2.accessToken).expect(201);
       await app.enterRoom(room.id, blockedUser1.accessToken).expect(201);
       await app.enterRoom(room.id, blockedUser2.accessToken).expect(201);
+      await app.enterRoom(room.id, kickedUser1.accessToken).expect(201);
     });
 
     // Setup promises to recv messages
@@ -389,6 +404,95 @@ describe('ChatGateway and ChatController (e2e)', () => {
 
     it('blockedUser1 receives ACK', async () => {
       await ctx4;
+    });
+
+    it('user1 should get all messages except from blockedUser2 in the room', async () => {
+      const res = await app
+        .getMessagesInRoom(room.id, user1.accessToken)
+        .expect(200);
+      const messages = res.body;
+      expect(messages).toHaveLength(5);
+      expect(messages).toEqual([
+        {
+          user: {
+            id: user1.id,
+            name: user1.name,
+            avatarURL: user1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: user2.id,
+            name: user2.name,
+            avatarURL: user2.avatarURL,
+          },
+          roomId: room.id,
+          content: 'ACK: hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: blockedUser1.id,
+            name: blockedUser1.name,
+            avatarURL: blockedUser1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: blockedUser1.id,
+            name: blockedUser1.name,
+            avatarURL: blockedUser1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'hello',
+          createdAt: expect.any(String),
+        },
+        {
+          user: {
+            id: user1.id,
+            name: user1.name,
+            avatarURL: user1.avatarURL,
+          },
+          roomId: room.id,
+          content: 'ACK: hello',
+          createdAt: expect.any(String),
+        },
+      ]);
+    });
+
+    it('user1 kicks kickedUser1', async () => {
+      await app
+        .kickFromRoom(room.id, kickedUser1.id, user1.accessToken)
+        .expect(204);
+    });
+
+    it('kickedUser1 sends message', () => {
+      const helloMessage = {
+        userId: kickedUser1.id,
+        roomId: room.id,
+        content: 'hello',
+      };
+      ws5.emit('message', helloMessage);
+    });
+
+    it('user1 and user2 should not receive message from kickedUser1', (done) => {
+      const mockMessage = jest.fn();
+      const mockMessage2 = jest.fn();
+      ws1.on('message', mockMessage);
+      ws2.on('message', mockMessage2);
+      setTimeout(() => {
+        expect(mockMessage).not.toBeCalled();
+        expect(mockMessage2).not.toBeCalled();
+        ws1.off('message');
+        ws2.off('message');
+        done();
+      }, 3000);
     });
 
     it('user1 should get all messages except from blockedUser2 in the room', async () => {


### PR DESCRIPTION
- kickしたユーザーがメッセージを送ったり、受け取ったり出来てしまっていたので修正しました。
- kickしたユーザーからのメッセージが届かないことを確認するテストを追加しました。
- kickしたユーザーが元いたroomのメッセージを受け取らないことを確認するテストを追加しました。
- kickのAPIが呼ばれて成功した時にsocketのroomからleaveするように修正しました。
- banも同様の現象が起きているので別PRで修正します。

追加したテスト
<img width="683" alt="スクリーンショット 2024-01-13 21 09 16" src="https://github.com/usatie/pong/assets/90199432/46071bf0-ab4b-4a2b-9410-e3a5e5670355">

