### PR TITLE
[backend] Fix ban user from room

### DIFF
--- a/backend/src/room/ban/ban.controller.spec.ts
+++ b/backend/src/room/ban/ban.controller.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { BanController } from './ban.controller';
@@ -9,7 +10,7 @@ describe('BanController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [BanController],
-      providers: [BanService, PrismaService],
+      providers: [BanService, PrismaService, EventEmitter2],
     }).compile();
 
     controller = module.get<BanController>(BanController);

--- a/backend/src/room/ban/ban.service.spec.ts
+++ b/backend/src/room/ban/ban.service.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { BanService } from './ban.service';
@@ -7,7 +8,7 @@ describe('BanService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BanService, PrismaService],
+      providers: [BanService, PrismaService, EventEmitter2],
     }).compile();
 
     service = module.get<BanService>(BanService);

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -711,6 +711,25 @@ describe('ChatGateway and ChatController (e2e)', () => {
         },
       ]);
     });
+
+    it('user1 sends message', () => {
+      const helloMessage = {
+        userId: user1.id,
+        roomId: room.id,
+        content: 'hello',
+      };
+      ws1.emit('message', helloMessage);
+    });
+
+    it('bannedUser1 should not receive message from user1', (done) => {
+      const mockMessage = jest.fn();
+      ws6.on('message', mockMessage);
+      setTimeout(() => {
+        expect(mockMessage).not.toBeCalled();
+        ws6.off('message');
+        done();
+      }, 3000);
+    });
   });
 
   /*


### PR DESCRIPTION
- banされたユーザーのメッセージが届かないことを確認するテストを追加しました。
- banされたユーザーが元いたルームからのメッセージを受け取らないことを確認するテストを追加しました。
- banのAPIが呼ばれた後にsocketのroomからleaveするように修正しました。
- frontend側でリロードせずに更新されるようにするためのbackend側の処理は別PRで追加します。

追加したテスト
<img width="691" alt="スクリーンショット 2024-01-13 23 12 46" src="https://github.com/usatie/pong/assets/90199432/2f8a249b-d2a8-4da8-88b9-f4843f29c023">
