### PR TITLE
[backend] Add API GET /room/direct/:userId

### DIFF
--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -71,6 +71,18 @@ export class RoomController {
     return new RoomEntity(await this.roomService.findRoom(roomId));
   }
 
+  @Get('direct/:userId')
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: RoomEntity })
+  async findOneDirect(
+    @CurrentUser() user: User,
+    @Param('userId', ParseIntPipe) userId: number,
+  ) {
+    return new RoomEntity(
+      await this.roomService.findDirectRoom(user.id, userId),
+    );
+  }
+
   @Patch(':roomId')
   @UseGuards(OwnerGuard, UpdateRoomGuard)
   @ApiBearerAuth()

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -88,6 +88,43 @@ export class RoomService {
     });
   }
 
+  findDirectRoom(userId: number, targetUserId: number) {
+    return this.prisma.room.findFirstOrThrow({
+      where: {
+        accessLevel: 'DIRECT',
+        AND: [
+          {
+            users: {
+              some: {
+                userId: userId,
+              },
+            },
+          },
+          {
+            users: {
+              some: {
+                userId: targetUserId,
+              },
+            },
+          },
+        ],
+      },
+      include: {
+        users: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                avatarURL: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
   findRoom(id: number) {
     return this.prisma.room.findUniqueOrThrow({
       where: { id },

--- a/backend/test/constants/user.ts
+++ b/backend/test/constants/user.ts
@@ -39,3 +39,9 @@ export const test2 = {
   email: 'test2@test.com',
   password: 'password-test2',
 };
+
+export const test3 = {
+  name: 'test_user3',
+  email: 'test3@test.com',
+  password: 'password-test3',
+};

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -350,7 +350,15 @@ describe('RoomController (e2e)', () => {
   describe('GET /room/direct/:userId (Get Direct Room)', () => {
     describe('user1', () => {
       it('should get direct room with user2 (200 OK)', () => {
-        return app.getDirectRoom(user2.id, user1.accessToken).expect(200);
+        return app
+          .getDirectRoom(user2.id, user1.accessToken)
+          .expect(200)
+          .expect((res) => {
+            const userIds = res.body.users.map((user) => user.userId);
+            expect(userIds).toContainEqual(user1.id);
+            expect(userIds).toContainEqual(user2.id);
+            expect(res.body.accessLevel).toEqual('DIRECT');
+          });
       });
       it('should not get direct room with user3 that has not created DM (404 Not Found)', () => {
         return app.getDirectRoom(user3.id, user1.accessToken).expect(404);
@@ -359,7 +367,15 @@ describe('RoomController (e2e)', () => {
 
     describe('user2', () => {
       it('should get direct room with user1 (200 OK)', () => {
-        return app.getDirectRoom(user1.id, user2.accessToken).expect(200);
+        return app
+          .getDirectRoom(user1.id, user2.accessToken)
+          .expect(200)
+          .expect((res) => {
+            const userIds = res.body.users.map((user) => user.userId);
+            expect(userIds).toContainEqual(user1.id);
+            expect(userIds).toContainEqual(user2.id);
+            expect(res.body.accessLevel).toEqual('DIRECT');
+          });
       });
       it('should not get direct room with user3 that has not created DM (404 Not Found)', () => {
         return app.getDirectRoom(user3.id, user2.accessToken).expect(404);

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('RoomController (e2e)', () => {
     current: T;
   }
   let owner, admin, member, notMember: UserEntityWithAccessToken;
-  let user1, user2: UserEntityWithAccessToken;
+  let user1, user2, user3: UserEntityWithAccessToken;
   const ownerRef: Ref<UserEntityWithAccessToken> = new Ref();
   const adminRef: Ref<UserEntityWithAccessToken> = new Ref();
   const memberRef: Ref<UserEntityWithAccessToken> = new Ref();
@@ -112,6 +112,7 @@ describe('RoomController (e2e)', () => {
     {
       user1 = await app.createAndLoginUser(constants.user.test);
       user2 = await app.createAndLoginUser(constants.user.test2);
+      user3 = await app.createAndLoginUser(constants.user.test3);
       directRoom = await app
         .createRoom(
           { ...constants.room.directRoom, userIds: [user2.id] },
@@ -130,7 +131,7 @@ describe('RoomController (e2e)', () => {
     await app.deleteRoom(protectedRoom.id, owner.accessToken).expect(204);
     await app.deleteRoom(directRoom.id, user1.accessToken).expect(204);
     // Delete users
-    for (const user of [owner, admin, member, notMember, user1, user2]) {
+    for (const user of [owner, admin, member, notMember, user1, user2, user3]) {
       await app.deleteUser(user.id, user.accessToken).expect(204);
     }
   });
@@ -344,6 +345,35 @@ describe('RoomController (e2e)', () => {
     });
 
     it('invalid roomId should return 404 Not Found (403?)', async () => {});
+  });
+
+  describe('GET /room/direct/:userId (Get Direct Room)', () => {
+    describe('user1', () => {
+      it('should get direct room with user2 (200 OK)', () => {
+        return app.getDirectRoom(user2.id, user1.accessToken).expect(200);
+      });
+      it('should not get direct room with user3 that has not created DM (404 Not Found)', () => {
+        return app.getDirectRoom(user3.id, user1.accessToken).expect(404);
+      });
+    });
+
+    describe('user2', () => {
+      it('should get direct room with user1 (200 OK)', () => {
+        return app.getDirectRoom(user1.id, user2.accessToken).expect(200);
+      });
+      it('should not get direct room with user3 that has not created DM (404 Not Found)', () => {
+        return app.getDirectRoom(user3.id, user2.accessToken).expect(404);
+      });
+    });
+
+    describe('user3', () => {
+      it('should not get direct room with user1 that has not created DM (404 Not Found)', () => {
+        return app.getDirectRoom(user1.id, user3.accessToken).expect(404);
+      });
+      it('should not get direct room with user2 that has not created DM (404 Not Found)', () => {
+        return app.getDirectRoom(user2.id, user3.accessToken).expect(404);
+      });
+    });
   });
 
   describe('POST /room/:id (Enter Room)', () => {

--- a/backend/test/utils/app.ts
+++ b/backend/test/utils/app.ts
@@ -94,6 +94,11 @@ export class TestApp {
       .get(`/room/${id}`)
       .set('Authorization', `Bearer ${accessToken}`);
 
+  getDirectRoom = (userId: number, accessToken: string) =>
+    request(this.app.getHttpServer())
+      .get(`/room/direct/${userId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
   updateRoom = (id: number, dto: UpdateRoomDto, accessToken: string) =>
     request(this.app.getHttpServer())
       .patch(`/room/${id}`)


### PR DESCRIPTION
DMが既に作成済みかの情報と作成済みの場合はroomIdが必要だったため GET /room/direct/:userId APIを追加しました。
- GET /room/direct/:userIdのテストを追加しました。
- GET /room/direct/:userId APIを追加しました。

追加したテスト
<img width="837" alt="スクリーンショット 2024-01-15 20 36 58" src="https://github.com/usatie/pong/assets/90199432/8c822a78-1fd8-4d2d-a20a-22e5ea4a32e4">
