### PR TITLE
[frontend] DM from user profile

### DIFF
--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -175,6 +175,23 @@ export async function getRoom(roomId: number): Promise<GetRoomResponse> {
   return room;
 }
 
+export async function getDirectRoom(userId: number) {
+  const res = await fetch(`${process.env.API_URL}/room/direct/${userId}`, {
+    cache: "no-cache",
+    headers: {
+      Authorization: "Bearer " + getAccessToken(),
+    },
+  });
+  const room = await res.json();
+  if (res.status === 404) {
+    return room;
+  } else if (!res.ok) {
+    console.error("getDirectRoom error: ", room);
+    throw new Error("getDirectRoom error");
+  }
+  return room;
+}
+
 export async function createRoom(
   prevState: { error?: string },
   formData: FormData,
@@ -208,6 +225,28 @@ export async function createRoom(
   const data = await res.json();
   if (!res.ok) {
     console.error("createRoom error: ", data);
+    return { error: data.message };
+  } else {
+    redirect(`/room/${data.id}`, RedirectType.push);
+  }
+}
+
+export async function createDirectRoom(userId: number) {
+  const res = await fetch(`${process.env.API_URL}/room`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + getAccessToken(),
+    },
+    body: JSON.stringify({
+      name: "DM",
+      accessLevel: "DIRECT",
+      userIds: [userId],
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    console.error("createDirectRoom error: ", data);
     return { error: data.message };
   } else {
     redirect(`/room/${data.id}`, RedirectType.push);

--- a/frontend/app/lib/dtos.ts
+++ b/frontend/app/lib/dtos.ts
@@ -1,4 +1,4 @@
-export type AccessLevel = "PUBLIC" | "PRIVATE" | "PROTECTED";
+export type AccessLevel = "PUBLIC" | "PRIVATE" | "PROTECTED" | "DIRECT";
 
 export type GetRoomResponse = {
   id: number;

--- a/frontend/app/room/[id]/dm-title.tsx
+++ b/frontend/app/room/[id]/dm-title.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { UserOnRoomEntity } from "@/app/lib/dtos";
+
+interface Props {
+  me: UserOnRoomEntity;
+  users: UserOnRoomEntity[];
+}
+
+export const DmTitle = ({ me, users }: Props) => {
+  const otherUser = users.find((user) => user.user.id !== me.user.id);
+
+  return (
+    <>
+      <div className="flex justify-between items-center h-10 border-b-2 mb-2">
+        <a className="text-md font-semibold">{otherUser?.user.name}</a>
+      </div>
+    </>
+  );
+};

--- a/frontend/app/room/[id]/room-detail.tsx
+++ b/frontend/app/room/[id]/room-detail.tsx
@@ -8,6 +8,7 @@ import { getCurrentUserId } from "@/app/lib/session";
 import { Stack } from "@/components/layout/stack";
 import SidebarItem from "./sidebar-item";
 import { SidebarMenu } from "./sidebar-menu";
+import { DmTitle } from "./dm-title";
 
 interface Props {
   room: RoomEntity;
@@ -25,17 +26,20 @@ export default async function RoomDetail({ room, users, allUsers }: Props) {
   const blockingUsers = (await getBlockingUsers()) ?? [];
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4 flex flex-col gap-2">
-      <SidebarMenu
-        room={room}
-        me={me}
-        allUsers={allUsers}
-        usersOnRoom={users}
-        bannedUsers={bannedUsers}
-      />
+      {room.accessLevel !== "DIRECT" && (
+        <SidebarMenu
+          room={room}
+          me={me}
+          allUsers={allUsers}
+          usersOnRoom={users}
+          bannedUsers={bannedUsers}
+        />
+      )}
+      {room.accessLevel === "DIRECT" && <DmTitle me={me} users={users} />}
       <Stack space="space-y-2">
         {users.map((user) => (
           <SidebarItem
-            roomId={room.id}
+            room={room}
             user={user}
             me={me}
             blockingUsers={blockingUsers}

--- a/frontend/app/room/[id]/sidebar-item.tsx
+++ b/frontend/app/room/[id]/sidebar-item.tsx
@@ -6,7 +6,11 @@ import {
   unblockUser,
   updateRoomUser,
 } from "@/app/lib/actions";
-import type { PublicUserEntity, UserOnRoomEntity } from "@/app/lib/dtos";
+import type {
+  PublicUserEntity,
+  RoomEntity,
+  UserOnRoomEntity,
+} from "@/app/lib/dtos";
 import { SmallAvatarSkeleton } from "@/app/ui/room/skeleton";
 import {
   ContextMenu,
@@ -36,12 +40,12 @@ function Avatar({ avatarURL }: { avatarURL?: string }) {
 }
 
 export default function SidebarItem({
-  roomId,
+  room,
   user,
   me,
   blockingUsers,
 }: {
-  roomId: number;
+  room: RoomEntity;
   user: UserOnRoomEntity;
   me: UserOnRoomEntity;
   blockingUsers: PublicUserEntity[];
@@ -74,10 +78,10 @@ export default function SidebarItem({
       setIsBlocked(false);
     }
   };
-  const kick = () => kickUserOnRoom(roomId, user.userId);
+  const kick = () => kickUserOnRoom(room.id, user.userId);
   const updateUserRole = isUserAdmin
-    ? () => updateRoomUser("MEMBER", roomId, user.userId)
-    : () => updateRoomUser("ADMINISTRATOR", roomId, user.userId);
+    ? () => updateRoomUser("MEMBER", room.id, user.userId)
+    : () => updateRoomUser("ADMINISTRATOR", room.id, user.userId);
   return (
     <>
       <ContextMenu>
@@ -85,8 +89,8 @@ export default function SidebarItem({
           <Avatar avatarURL={user.user.avatarURL} />
           <span className="text-muted-foreground text-sm whitespace-nowrap group-hover:text-primary">
             {truncateString(user.user.name, 15)}
-            {isUserOwner && " 👑"}
-            {isUserAdmin && " 🛡"}
+            {room.accessLevel !== "DIRECT" && isUserOwner && " 👑"}
+            {room.accessLevel !== "DIRECT" && isUserAdmin && " 🛡"}
           </span>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-56">

--- a/frontend/app/ui/room/setting-modal.tsx
+++ b/frontend/app/ui/room/setting-modal.tsx
@@ -20,7 +20,7 @@ import * as z from "zod";
 const settingSchema = z.discriminatedUnion("selectedAccessLevel", [
   z.object({
     roomName: z.string().min(1, { message: "Please enter room name" }),
-    selectedAccessLevel: z.enum(["PUBLIC", "PRIVATE"]),
+    selectedAccessLevel: z.enum(["PUBLIC", "PRIVATE", "DIRECT"]),
     password: z.string().optional(),
   }),
   z.object({

--- a/frontend/app/ui/user/direct-message-button.tsx
+++ b/frontend/app/ui/user/direct-message-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { getDirectRoom, createDirectRoom } from "@/app/lib/actions";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+export default function DirectMessageButton({ id }: { id: number }) {
+  const router = useRouter();
+  const onClick = async () => {
+    const room = await getDirectRoom(id);
+    console.log(room);
+    if (room.statusCode === 404) {
+      await createDirectRoom(id);
+    } else {
+      router.push(`/room/${room.id}`);
+    }
+  };
+  return <Button onClick={onClick}>Message</Button>;
+}

--- a/frontend/app/user/[id]/page.tsx
+++ b/frontend/app/user/[id]/page.tsx
@@ -10,6 +10,7 @@ import AddFriendButton from "@/app/ui/user/add-friend-button";
 import BlockButton from "@/app/ui/user/block-button";
 import { Avatar } from "@/app/ui/user/avatar";
 import CancelFriendRequestButton from "@/app/ui/user/cancel-friend-request-button";
+import DirectMessageButton from "@/app/ui/user/direct-message-button";
 import Friends from "@/app/ui/user/friends";
 import MatchHistory from "@/app/ui/user/match-history";
 import MatchRequestButton from "@/app/ui/user/match-request-button";
@@ -60,6 +61,7 @@ export default async function FindUser({
             {!isBlocking && <BlockButton id={userId} />}
             {isBlocking && <UnBlockButton id={userId} />}
           </div>
+          <DirectMessageButton id={userId} />
           <MatchRequestButton id={userId} />
         </>
       )}


### PR DESCRIPTION
- ユーザープロフィール画面にDMの作成orDM画面に飛ぶボタンを追加しました。
- DMに合わせて一部UIを修正しました。(DropDownMenuを無くしてban/leaveを出来ないように変更、room名になっていた箇所をDMの相手の名前に変更)
- DMのデフォルトのルーム名は仮置きでDMになっています。
- rooms-sidebar上で表示するDMの名前を相手のユーザー名にするよい方法が思いつかず、名前がDMのroomが複数表示されてクリックして中身を確認するまで区別がつかなくなっています。
<img width="1440" alt="スクリーンショット 2024-01-16 2 15 15" src="https://github.com/usatie/pong/assets/90199432/dfd000a9-bcea-4d1b-8b48-cc096bc4bbbd">
<img width="1440" alt="スクリーンショット 2024-01-16 2 16 57" src="https://github.com/usatie/pong/assets/90199432/e0f4337e-94a0-406e-850f-9f33ff09f36d">

