### PR TITLE
[backend] backend のendpoint を起点として oauth sign up and sign を行う

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
     "nestjs-prisma": "^0.22.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -26,6 +26,19 @@ export class AuthController {
     return this.authService.login(email, password);
   }
 
+  @Get('signup/oauth2/42')
+  @ApiOkResponse({ type: AuthEntity })
+  @Redirect('url', 302)
+  redirectToOauth42() {
+    return this.authService.redirectToOauth42('/signup/oauth2/42/callback');
+  }
+
+  @Get('signup/oauth2/42/callback')
+  @ApiOkResponse({ type: AuthEntity })
+  oauth42Callback(@Query('code') code: string) {
+    return this.authService.oauth42Callback(code);
+  }
+
   @Post('oauth2/signup/42')
   @ApiCreatedResponse({ type: AuthEntity })
   async signupWith42(@Body() dto: OauthDto) {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -38,15 +38,17 @@ export class AuthController {
 
   @Get('signup/oauth2/42')
   @ApiOkResponse({ type: AuthEntity })
-  @Redirect('url', 302)
+  @Redirect()
   redirectToOauth42() {
-    return this.authService.redirectToOauth42('/signup/oauth2/42/callback');
+    return this.authService.redirectToOauth42(
+      '/auth/signup/oauth2/42/callback',
+    );
   }
 
   @Get('signup/oauth2/42/callback')
   @ApiOkResponse({ type: AuthEntity })
-  oauth42Callback(@Query('code') code: string) {
-    return this.authService.oauth42Callback(code);
+  signupWithOauth42(@Query('code') code: string) {
+    return this.authService.signupWithOauth42(code);
   }
 
   @Get('login/oauth2/42')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  Query,
+  Redirect,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
@@ -9,11 +19,11 @@ import type { User } from '@prisma/client';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
-import { OauthDto } from './dto/oauth.dto';
 import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';
 import { TwoFactorAuthenticationEnableDto } from './dto/twoFactorAuthenticationEnable.dto';
 import { AuthEntity } from './entity/auth.entity';
 import { JwtGuardWithout2FA } from './jwt-auth.guard';
+import { Response } from 'express';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -39,10 +49,20 @@ export class AuthController {
     return this.authService.oauth42Callback(code);
   }
 
-  @Post('oauth2/signup/42')
-  @ApiCreatedResponse({ type: AuthEntity })
-  async signupWith42(@Body() dto: OauthDto) {
-    return this.authService.signupWith42(dto);
+  @Get('login/oauth2/42')
+  @ApiOkResponse({ type: AuthEntity })
+  @Redirect()
+  redirectToOauth42ToLogin() {
+    return this.authService.redirectToOauth42('/auth/login/oauth2/42/callback');
+  }
+
+  @Get('login/oauth2/42/callback')
+  @ApiOkResponse({ type: AuthEntity })
+  loginWithOauth42(@Query('code') code: string, @Res() res: Response) {
+    return this.authService.loginWithOauth42(code).then((auth) => {
+      res.cookie('token', auth.accessToken);
+      res.redirect('/');
+    });
   }
 
   @Post('2fa/generate')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -11,7 +11,6 @@ import * as bcrypt from 'bcrypt';
 import { authenticator } from 'otplib';
 import { toFileStream } from 'qrcode';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { UserEntity } from 'src/user/entities/user.entity';
 import { jwtConstants } from './auth.module';
 import { TwoFactorAuthenticationDto } from './dto/twoFactorAuthentication.dto';

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2226,10 +2226,23 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-parser@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
+  dependencies:
+    cookie "0.4.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookie@0.5.0:
   version "0.5.0"

--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,6 @@ services:
       TWO_FACTOR_AUTHENTICATION_APP_NAME: ${TWO_FACTOR_AUTHENTICATION_APP_NAME}
       OAUTH_42_CLIENT_ID: ${OAUTH_42_CLIENT_ID}
       OAUTH_42_CLIENT_SECRET: ${OAUTH_42_CLIENT_SECRET}
-      OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${BACKEND_PORT}/api"]
       interval: 5s

--- a/frontend/app/(guest-only)/login/page.tsx
+++ b/frontend/app/(guest-only)/login/page.tsx
@@ -1,5 +1,10 @@
 import LoginForm from "@/app/ui/auth/login-form";
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <>
+      <LoginForm />
+      <a href="http://localhost:4242/api/auth/login/oauth2/42">login with 42</a>
+    </>
+  );
 }

--- a/frontend/app/(guest-only)/signup/page.tsx
+++ b/frontend/app/(guest-only)/signup/page.tsx
@@ -2,5 +2,12 @@
 import SignUpForm from "@/app/ui/auth/signup-form";
 
 export default function SignUp() {
-  return <SignUpForm />;
+  return (
+    <>
+      <SignUpForm />
+      <a href="http://localhost:4242/api/auth/signup/oauth2/42">
+        sign up with 42
+      </a>
+    </>
+  );
 }


### PR DESCRIPTION
昨日の集まりの中で backend への リクエストだけでoauth 完結した方がシンプルなんじゃないかとアイデアを頂いた。
確かに! と思って、自分の中での front と back の理解を確認するためにも back だけで実装しました。
写真のpage の ... with 42 が、それぞれのbackend のリンクになっており、sign up と login ができるようになっています.

<img width="589" alt="image" src="https://github.com/usatie/pong/assets/97882386/8d831956-f074-40e0-98e6-1826fe528cf2">

![image](https://github.com/usatie/pong/assets/97882386/95117c64-20b4-40f9-95d0-434ea9a6d43f)


TODO
- "oauth は認証プロトコルではない" という言葉が理解できていない. 特にlogin 時のoauth の使い方に関わると思うが、安全なのかわからない
- profile の image を取得する
- [db] user の sign in 方法 ( 通常か 42oauth か) または複数許すのか
- [db] oauth のみでlogin するユーザもいるので、password を null 許容する