### PR TITLE
[frontend] mute user in room

### DIFF
--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -739,8 +739,9 @@ export async function muteUser(
   userId: number,
   durationSec?: number,
 ) {
-  console.log("muteUser", durationSec);
-  console.log(typeof durationSec);
+  if (durationSec && durationSec < 0) {
+    throw new Error("Duration must be positive");
+  }
   const res = await fetch(
     `${process.env.API_URL}/room/${roomId}/mutes/${userId}`,
     {

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -734,6 +734,65 @@ export async function twoFactorAuthenticate(
   }
 }
 
+export async function muteUser(
+  roomId: number,
+  userId: number,
+  durationSec?: number,
+) {
+  console.log("muteUser", durationSec);
+  console.log(typeof durationSec);
+  const res = await fetch(
+    `${process.env.API_URL}/room/${roomId}/mutes/${userId}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer " + getAccessToken(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ duration: durationSec }),
+    },
+  );
+  if (!res.ok) {
+    console.error("muteUser error: ", await res.json());
+    return "Error";
+  } else {
+    return "Success";
+  }
+}
+
+export async function getMutedUsers(roomId: number) {
+  const res = await fetch(`${process.env.API_URL}/room/${roomId}/mutes`, {
+    headers: {
+      Authorization: "Bearer " + getAccessToken(),
+    },
+  });
+  if (!res.ok) {
+    console.error("getMutedUsers error: ", await res.json());
+    return null;
+  } else {
+    const mutedUsers = res.json();
+    return mutedUsers;
+  }
+}
+
+export async function unmuteUser(roomId: number, userId: number) {
+  const res = await fetch(
+    `${process.env.API_URL}/room/${roomId}/mutes/${userId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: "Bearer " + getAccessToken(),
+      },
+    },
+  );
+  if (!res.ok) {
+    console.error("unmuteUser error: ", await res.json());
+    return "Error";
+  } else {
+    return "Success";
+  }
+}
+
 export async function banUser(roomId: number, userId: number) {
   const res = await fetch(
     `${process.env.API_URL}/room/${roomId}/bans/${userId}`,
@@ -761,7 +820,7 @@ export async function getBannedUsers(roomId: number) {
   });
   if (!res.ok) {
     console.error("getBannedUsers error: ", await res.json());
-    return "Error";
+    return null;
   } else {
     const bannedUsers = res.json();
     return bannedUsers;

--- a/frontend/app/room/[id]/room-detail.tsx
+++ b/frontend/app/room/[id]/room-detail.tsx
@@ -1,4 +1,8 @@
-import { getBannedUsers, getBlockingUsers } from "@/app/lib/actions";
+import {
+  getBannedUsers,
+  getBlockingUsers,
+  getMutedUsers,
+} from "@/app/lib/actions";
 import type {
   PublicUserEntity,
   RoomEntity,
@@ -24,6 +28,7 @@ export default async function RoomDetail({ room, users, allUsers }: Props) {
   }
   const bannedUsers = (await getBannedUsers(room.id)) ?? [];
   const blockingUsers = (await getBlockingUsers()) ?? [];
+  const mutedUsers = (await getMutedUsers(room.id)) ?? [];
   return (
     <div className="overflow-y-auto shrink-0 basis-36 pb-4 flex flex-col gap-2">
       {room.accessLevel !== "DIRECT" && (
@@ -43,6 +48,7 @@ export default async function RoomDetail({ room, users, allUsers }: Props) {
             user={user}
             me={me}
             blockingUsers={blockingUsers}
+            mutedUsers={mutedUsers}
             key={user.userId}
           />
         ))}


### PR DESCRIPTION
- muteに関するAPIを呼び出す関数をactionsに追加しました。
- Dropdown menuにmuteのボタンを追加しました。
- API呼び出しの結果が失敗していた時のユーザーへのフィードバックなどはまだ実装していません。

For 5minutes以外はDiscordに倣ったmute期間にしています。
<img width="403" alt="スクリーンショット 2024-01-21 4 37 03" src="https://github.com/usatie/pong/assets/90199432/101dfdf4-a4fb-4d55-8473-eb676fb4bcfd">
<img width="377" alt="スクリーンショット 2024-01-21 5 23 24" src="https://github.com/usatie/pong/assets/90199432/39c1680a-400f-499f-9eca-216016139b9b">

