### PR TITLE
[frontend] user can go other user profile with chat interface.

### DIFF
--- a/frontend/app/ui/room/message-item.tsx
+++ b/frontend/app/ui/room/message-item.tsx
@@ -1,6 +1,8 @@
 import type { MessageEvent } from "@/app/lib/dtos";
 import { Avatar } from "@/app/ui/user/avatar";
 import { Stack } from "@/components/layout/stack";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import UserTooltip from "../user/user-tool-tip";
 
 export function MessageItem({
   message,
@@ -15,7 +17,9 @@ export function MessageItem({
     <div className="flex gap-4 group hover:opacity-60">
       {/* Left Side */}
       {withAvatar && (
-        <Avatar avatarURL={message.user.avatarURL} size="medium" />
+        <TooltipProvider>
+          <UserTooltip user={message.user} avatarSize="medium"></UserTooltip>
+        </TooltipProvider>
       )}
       {!withAvatar && (
         <div className="group-hover:text-muted-foreground flex-none text-background text-xs w-10 text-center">


### PR DESCRIPTION
1 課題要件に、"with chat interface." と明示的に書いてあった
2 でも、chat room のところからは何をクリックしても user のprofile には飛べなかった
3 message に avatar をつけているところを、usertoolpic に差し替えることでprofile に飛ぶようにした。

(そもそも、profile 画像だけ見せたいところなんてない気がする ( avatar が表示されるところは全て profile に飛びたい ) ので
frontend の page.tsx では Avatar component の呼び出しをするところ全てusertoolpic　に差し替えてもいい気がする)

![image](https://github.com/usatie/pong/assets/97882386/42a92d99-9bea-4742-8bd5-d571c5429f6b)
![image](https://github.com/usatie/pong/assets/97882386/c32f93c7-9437-4769-aba5-91588dc65758)
