### PR TITLE
[backend] oauth signup without password

### DIFF
--- a/backend/prisma/migrations/20240121041719_add_oauth_enabled_culumn_with_user/migration.sql
+++ b/backend/prisma/migrations/20240121041719_add_oauth_enabled_culumn_with_user/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "oauthEnabled" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "password" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id        Int     @id @default(autoincrement())
   email     String  @unique
   name      String  @unique
-  password  String
+  password  String?
   avatarURL String?
 
   // Chat
@@ -43,6 +43,9 @@ model User {
   Message          Message[]
   BannedRooms      BanUserOnRoom[]
   MutedRooms       MuteUserOnRoom[]
+
+  // oauth
+  oauthEnabled Boolean @default(false)
 }
 
 model Room {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -47,7 +47,8 @@ export class AuthController {
 
   @Get('signup/oauth2/42/callback')
   @ApiOkResponse({ type: AuthEntity })
-  signupWithOauth42(@Query('code') code: string) {
+  @Redirect('/login')
+  async signupWithOauth42(@Query('code') code: string) {
     return this.authService.signupWithOauth42(code);
   }
 

--- a/backend/src/user/entities/public-user.entity.ts
+++ b/backend/src/user/entities/public-user.entity.ts
@@ -27,4 +27,7 @@ export class PublicUserEntity implements User {
 
   @Exclude()
   twoFactorEnabled: boolean;
+
+  @Exclude()
+  oauthEnabled: boolean;
 }

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -27,4 +27,7 @@ export class UserEntity implements User {
 
   @ApiProperty()
   twoFactorEnabled: boolean;
+
+  @Exclude()
+  oauthEnabled: boolean;
 }

--- a/backend/test/user.e2e-spec.ts
+++ b/backend/test/user.e2e-spec.ts
@@ -76,6 +76,15 @@ describe('UserController (e2e)', () => {
       };
       return app.createUser(dto).expect(400);
     });
+
+    it('POST /user with empty password should return 400 Bad Request', () => {
+      const dto = {
+        name: constants.user.test.name,
+        email: constants.user.test.email,
+        password: '',
+      };
+      return app.createUser(dto).expect(400);
+    });
   });
 
   describe('Invalid authentication', () => {

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
       TWO_FACTOR_AUTHENTICATION_APP_NAME: ${TWO_FACTOR_AUTHENTICATION_APP_NAME}
       OAUTH_42_CLIENT_ID: ${OAUTH_42_CLIENT_ID}
       OAUTH_42_CLIENT_SECRET: ${OAUTH_42_CLIENT_SECRET}
+      NEST_PUBLIC_API_URL: ${PUBLIC_API_URL}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${BACKEND_PORT}/api"]
       interval: 5s


### PR DESCRIPTION
- 環境変数が一つ設定し忘れていたので、redirect 先に飛べないようになってしまっていました。飛べるようにしました
- oauth signup したuser は適当なpassword が割り当てられていましたが、password 無しでsignup するようになりました
- user table の password が nonnull から null 許容になりました
- user table に oauthEnabled (Boolean) を追加しました.
- oauthEnabledが true な場合、sign in は oauth フローでのみ、false な場合 password フローでのみログインできます

TODO
- oauthEnabled が true なuser に、change password を成功させるのが不可能. ( 対応するか、あるいはコンポーネントを非表示にするか? )