### PR TITLE
[backend] invite to play

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -68,7 +68,7 @@ export class ChatGateway {
     );
   }
 
-  @SubscribeMessage('invitePong')
+  @SubscribeMessage('invite-pong')
   async handleInvitePong(
     @MessageBody() data: { userId: number },
     @ConnectedSocket() client: Socket,
@@ -80,7 +80,7 @@ export class ChatGateway {
     } else {
       this.server
         .to(invitedUserWsId)
-        .emit('invitePong', { userId: inviteUser.id });
+        .emit('invite-pong', { userId: inviteUser.id });
     }
   }
 

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -79,11 +79,21 @@ export class ChatGateway {
     if (!invitedUserWsId) {
       return;
     } else {
+      const blockings = await this.chatService.getUsersBlockedBy(data.userId);
+      if (blockings.some((user) => user.id === inviteUser.id)) return;
+      const blocked = await this.chatService.getUsersBlockedBy(inviteUser.id);
+      if (blocked.some((user) => user.id === data.userId)) return;
       this.server
         .to(invitedUserWsId)
         .emit('invite-pong', { userId: inviteUser.id });
       this.chatService.addInvite(inviteUser.id, data.userId);
     }
+  }
+
+  @SubscribeMessage('invite-cancel-pong')
+  handleInviteCancelPong(@ConnectedSocket() client: Socket) {
+    const inviteUser = this.chatService.getUser(client);
+    this.chatService.removeInvite(inviteUser.id);
   }
 
   @SubscribeMessage('approve-pong')

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -109,7 +109,9 @@ export class ChatGateway {
         this.chatService.getInvite(data.userId) !==
         this.chatService.getUserId(client)
       ) {
-        client.emit('error-pong', 'No pending invite found.');
+        this.server
+          .to(client.id)
+          .emit('error-pong', 'No pending invite found.');
         return;
       }
       const emitData = { roomId: v4() };

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -108,8 +108,10 @@ export class ChatGateway {
       if (
         this.chatService.getInvite(data.userId) !==
         this.chatService.getUserId(client)
-      )
+      ) {
+        client.emit('error-pong', 'No pending invite found.');
         return;
+      }
       const emitData = { roomId: v4() };
       this.server.to(client.id).emit('match-pong', emitData);
       this.server.to(approvedUserWsId).emit('match-pong', emitData);

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -68,6 +68,22 @@ export class ChatGateway {
     );
   }
 
+  @SubscribeMessage('invitePong')
+  async handleInvitePong(
+    @MessageBody() data: { userId: number },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const inviteUser = this.chatService.getUser(client);
+    const invitedUserWsId = this.chatService.getWsFromUserId(data.userId)?.id;
+    if (!invitedUserWsId) {
+      return;
+    } else {
+      this.server
+        .to(invitedUserWsId)
+        .emit('invitePong', { userId: inviteUser.id });
+    }
+  }
+
   @OnEvent('room.leave', { async: true })
   async handleLeave(event: RoomLeftEvent) {
     this.server.in(event.roomId.toString()).emit('leave', event);

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -77,6 +77,15 @@ export class ChatService {
     }
   }
 
+  getUsersBlockedBy(userId: number) {
+    return this.prisma.user
+      .findUniqueOrThrow({
+        where: { id: userId },
+        include: { blocking: true },
+      })
+      .then((user) => user.blocking);
+  }
+
   @OnEvent('room.created', { async: true })
   async handleRoomCreatedEvent(event: RoomCreatedEvent) {
     await this.addUserToRoom(event.roomId, event.userId);

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -54,6 +54,7 @@ export class ChatService {
     if (user) {
       this.clients.delete(user.id);
       this.users.delete(client.id);
+      this.removeInvite(user.id);
     }
   }
 

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -30,6 +30,10 @@ export class ChatService {
     return this.users.get(client.id);
   }
 
+  getWsFromUserId(userId: number): Socket | undefined {
+    return this.clients.get(userId);
+  }
+
   getUserId(client: Socket) {
     const user = this.users.get(client.id);
     if (user) {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -25,6 +25,8 @@ export class ChatService {
   // Map<User.id, Socket>
   private clients = new Map<User['id'], Socket>();
   private users = new Map<Socket['id'], User>();
+  // key: inviter, value: invitee
+  private invite = new Map<User['id'], User['id']>();
 
   getUser(client: Socket) {
     return this.users.get(client.id);
@@ -53,6 +55,18 @@ export class ChatService {
       this.clients.delete(user.id);
       this.users.delete(client.id);
     }
+  }
+
+  addInvite(inviterId: number, inviteeId: number) {
+    this.invite.set(inviterId, inviteeId);
+  }
+
+  getInvite(inviterId: number) {
+    return this.invite.get(inviterId);
+  }
+
+  removeInvite(inviterId: number) {
+    this.invite.delete(inviterId);
   }
 
   addUserToRoom(roomId: number, userId: number) {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1250,7 +1250,8 @@ describe('ChatGateway and ChatController (e2e)', () => {
           });
         });
         // TODO: 複数のuser から invite されるケース
-        it('user should receive error message', () => errorCtx);
+        it('should receive an error when approving without an existing invite', () =>
+          errorCtx);
         it('user should not receive approve message from not invite user', () =>
           new Promise<void>((resolve) =>
             setTimeout(() => {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1109,33 +1109,36 @@ describe('ChatGateway and ChatController (e2e)', () => {
             }, 1000),
           ));
       });
+      describe('invite -> cancel -> invite', () => {
+        let invitee;
+        let inviter;
+        let mockCallback;
+
+        beforeAll(() => {
+          mockCallback = jest.fn();
+          invitee = userAndSockets[0];
+          inviter = userAndSockets[1];
+
+          invitee.ws.on('invite-pong', mockCallback);
           inviter.ws.emit('invite-pong', {
             userId: invitee.user.id,
           });
-          return promiseToInvite.then((data) => {
-            invitee.ws.emit('approve-pong', {
-              userId: data.userId,
-            });
+          inviter.ws.emit('invite-cancel-pong', {
+            userId: invitee.user.id,
+          });
+          inviter.ws.emit('invite-pong', {
+            userId: invitee.user.id,
           });
         });
-        it("invite user should receive room's id", () =>
-          PromiseToMatchByInviter.then((data) => {
-            expect(data).toHaveProperty('roomId');
-            roomId = data.roomId;
-          }));
-        it("approve user should receive room's id", () =>
-          PromiseToMatchByInvited.then((data) => {
-            expect(data).toHaveProperty('roomId');
-            expect(data.roomId).toEqual(roomId);
-          }));
-        it('unrelated user should not receive any messages', () =>
+        it('user who is invited should receive invite message once per time', () =>
           new Promise<void>((resolve) =>
             setTimeout(() => {
-              expect(mockCallback1).not.toBeCalled();
+              expect(mockCallback).toHaveBeenCalledTimes(2);
               resolve();
             }, 1000),
           ));
       });
+    });
       describe('success case', () => {
         let PromiseToMatchByInviter: Promise<any>;
         let PromiseToMatchByInvited: Promise<any>;

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1074,68 +1074,41 @@ describe('ChatGateway and ChatController (e2e)', () => {
       });
     });
     describe('invite a user', () => {
-      let invite: UserAndSocket;
-      let invited: UserAndSocket;
-      let notInvited: UserAndSocket;
+      describe('success case', () => {
+        let invite: UserAndSocket;
+        let invited: UserAndSocket;
+        let notInvited: UserAndSocket;
 
-      let ctx1: Promise<any>;
-      const mockCallback = jest.fn();
+        let ctx1: Promise<any>;
+        const mockCallback = jest.fn();
 
-      beforeAll(() => {
-        invite = userAndSockets[0];
-        invited = userAndSockets[1];
-        notInvited = userAndSockets[2];
-        ctx1 = new Promise<any>((resolve) =>
-          invited.ws.on('invite-pong', (data) => resolve(data)),
-        );
-        notInvited.ws.on('invite-pong', mockCallback);
+        beforeAll(() => {
+          invite = userAndSockets[0];
+          invited = userAndSockets[1];
+          notInvited = userAndSockets[2];
+          ctx1 = new Promise<any>((resolve) =>
+            invited.ws.on('invite-pong', (data) => resolve(data)),
+          );
+          notInvited.ws.on('invite-pong', mockCallback);
 
-        invite.ws.emit('invite-pong', {
-          userId: invited.user.id,
-        });
-        ctx1.then((data) => {
-          expect(data).toEqual({
-            userId: invite.user.id,
+          invite.ws.emit('invite-pong', {
+            userId: invited.user.id,
+          });
+          ctx1.then((data) => {
+            expect(data).toEqual({
+              userId: invite.user.id,
+            });
           });
         });
+        it('user who is invited should receive invite message', () => ctx1);
+        it("user who isn't invited should not receive invite message", () =>
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              expect(mockCallback).not.toBeCalled();
+              resolve();
+            }, 1000),
+          ));
       });
-      it('user who is invited should receive invite message', () => ctx1);
-      it("user who isn't invited should not receive invite message", () =>
-        new Promise<void>((resolve) =>
-          setTimeout(() => {
-            expect(mockCallback).not.toBeCalled();
-            resolve();
-          }, 1000),
-        ));
-    });
-    describe('approve invite', () => {
-      // TODO: invite する前に approve 送られるケース
-      // TODO: 複数のuser から invite されるケース
-
-      describe('success case', () => {
-        let PromiseToMatchByInviter: Promise<any>;
-        let PromiseToMatchByInvited: Promise<any>;
-        let roomId;
-        const mockCallback1 = jest.fn();
-        beforeAll(() => {
-          const inviter = userAndSockets[0];
-          const invitee = userAndSockets[1];
-          const notInvited1 = userAndSockets[2];
-
-          const promiseToInvite = new Promise<any>((resolve) =>
-            invitee.ws.on('invite-pong', (data) => resolve(data)),
-          );
-          PromiseToMatchByInviter = new Promise<any>((resolve) =>
-            inviter.ws.on('match-pong', (data) => resolve(data)),
-          );
-          PromiseToMatchByInvited = new Promise<any>((resolve) =>
-            invitee.ws.on('match-pong', (data) => resolve(data)),
-          );
-
-          notInvited1.ws.on('invite-pong', mockCallback1);
-          notInvited1.ws.on('approve-pong', mockCallback1);
-          notInvited1.ws.on('match-pong', mockCallback1);
-
           inviter.ws.emit('invite-pong', {
             userId: invitee.user.id,
           });

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1241,7 +1241,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
 
           emitter.ws.on('match-pong', mockCallback1);
           errorCtx = new Promise<any>((resolve) =>
-            listener.ws.on('error-pong', (data) => resolve(data)),
+            emitter.ws.on('error-pong', (data) => resolve(data)),
           );
           listener.ws.on('match-pong', mockCallback2);
 

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1233,17 +1233,16 @@ describe('ChatGateway and ChatController (e2e)', () => {
       describe('failure case', () => {
         const mockCallback1 = jest.fn();
         const mockCallback2 = jest.fn();
+        let errorCtx: Promise<any>;
 
         beforeAll(() => {
           const emitter = userAndSockets[0];
           const listener = userAndSockets[1];
 
-          emitter.ws.on('invite-pong', mockCallback1);
-          emitter.ws.on('approve-pong', mockCallback1);
           emitter.ws.on('match-pong', mockCallback1);
-
-          listener.ws.on('invite-pong', mockCallback2);
-          listener.ws.on('approve-pong', mockCallback2);
+          errorCtx = new Promise<any>((resolve) =>
+            listener.ws.on('error-pong', (data) => resolve(data)),
+          );
           listener.ws.on('match-pong', mockCallback2);
 
           emitter.ws.emit('approve-pong', {
@@ -1251,11 +1250,12 @@ describe('ChatGateway and ChatController (e2e)', () => {
           });
         });
         // TODO: 複数のuser から invite されるケース
+        it('user should receive error message', () => errorCtx);
         it('user should not receive approve message from not invite user', () =>
           new Promise<void>((resolve) =>
             setTimeout(() => {
-              expect(mockCallback1).not.toBeCalled();
-              expect(mockCallback2).not.toBeCalled();
+              expect(mockCallback1).not.toHaveBeenCalled();
+              expect(mockCallback2).not.toHaveBeenCalled();
               resolve();
             }, 1000),
           ));

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1063,12 +1063,15 @@ describe('ChatGateway and ChatController (e2e)', () => {
       }));
     });
     afterAll(() => {
-      userAndSockets.map((userAndSocket) => userAndSocket.ws.close());
+      userAndSockets.map((userAndSocket) => {
+        userAndSocket.ws.close();
+      });
     });
     afterEach(() => {
-      userAndSockets.map((userAndSocket) =>
-        userAndSocket.ws.removeAllListeners(),
-      );
+      userAndSockets.map((us) => {
+        us.ws.disconnect();
+        us.ws.connect();
+      });
     });
     describe('invite a user', () => {
       let invite: UserAndSocket;

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1078,11 +1078,11 @@ describe('ChatGateway and ChatController (e2e)', () => {
         invited = userAndSockets[1];
         notInvited = userAndSockets[2];
         ctx1 = new Promise<any>((resolve) =>
-          invited.ws.on('invitePong', (data) => resolve(data)),
+          invited.ws.on('invite-pong', (data) => resolve(data)),
         );
-        notInvited.ws.on('invitePong', mockCallback);
+        notInvited.ws.on('invite-pong', mockCallback);
 
-        invite.ws.emit('invitePong', {
+        invite.ws.emit('invite-pong', {
           userId: invited.user.id,
         });
         ctx1.then((data) => {


### PR DESCRIPTION
- test を追加しました
- chat namespace にevent を追加しました
  - invite-pong (誰かをinviteする)
  - invite-cancel-pong (invite した人が invite をキャンセルする)
  - approve-pong (invite を受理する) (invite してきていない相手のことは approve を送っても試合開始されない)
  - match-pong (approve すると、両者に 当イベントでroomId が送られる) 

- block している されている user には invite 出来ない. ( server 側で制御 )
web socket を使うテストでは、綺麗に書けたんじゃないかなって思います!
- エラー時 (approve ) にクライアントにエラーメッセージを送信

TODO
- frontend側
- deny-pong

- message と name space は分けなくていいのか?
    - 分けてない状態でエラーメッセージを送ろうとすると、'error' イベントが被る可能性がある。

<img width="831" alt="image" src="https://github.com/usatie/pong/assets/97882386/e7a9b7f9-a79d-45dc-834b-e866b13f4d49">
