### PR TITLE
[backend] Client notification on chat channel actions

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -9,6 +9,8 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
+import { RoomMuteEvent } from 'src/common/events/room-mute.event';
+import { RoomUnmuteEvent } from 'src/common/events/room-unmute.event';
 import { RoomLeftEvent } from 'src/common/events/room-left.event';
 import { RoomUpdateRoleEvent } from 'src/common/events/room-update-role.event';
 import { ChatService } from './chat.service';
@@ -168,6 +170,16 @@ export class ChatGateway {
   @OnEvent('room.update.role', { async: true })
   async handleUpdateRole(event: RoomUpdateRoleEvent) {
     this.server.in(event.roomId.toString()).emit('update-role', event);
+  }
+
+  @OnEvent('room.mute', { async: true })
+  async handleMute(event: RoomMuteEvent) {
+    this.server.in(event.roomId.toString()).emit('mute', event);
+  }
+
+  @OnEvent('room.unmute', { async: true })
+  async handleUnmute(event: RoomUnmuteEvent) {
+    this.server.in(event.roomId.toString()).emit('unmute', event);
   }
 
   async handleConnection(@ConnectedSocket() client: Socket) {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -6,7 +6,6 @@ import { Socket } from 'socket.io';
 import { AuthService } from 'src/auth/auth.service';
 import { BlockEvent } from 'src/common/events/block.event';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
-import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
 import { RoomLeftEvent } from 'src/common/events/room-left.event';
 import { UnblockEvent } from 'src/common/events/unblock.event';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -89,11 +88,6 @@ export class ChatService {
 
   @OnEvent('room.created', { async: true })
   async handleRoomCreatedEvent(event: RoomCreatedEvent) {
-    await this.addUserToRoom(event.roomId, event.userId);
-  }
-
-  @OnEvent('room.enter', { async: true })
-  async handleUserOnRoomCreatedEvent(event: RoomEnteredEvent) {
     await this.addUserToRoom(event.roomId, event.userId);
   }
 

--- a/backend/src/common/events/room-mute.event.ts
+++ b/backend/src/common/events/room-mute.event.ts
@@ -1,0 +1,4 @@
+export class RoomMuteEvent {
+  roomId: number;
+  userId: number;
+}

--- a/backend/src/common/events/room-unmute.event.ts
+++ b/backend/src/common/events/room-unmute.event.ts
@@ -1,0 +1,4 @@
+export class RoomUnmuteEvent {
+  roomId: number;
+  userId: number;
+}

--- a/backend/src/common/events/room-update-role.event.ts
+++ b/backend/src/common/events/room-update-role.event.ts
@@ -1,3 +1,7 @@
+import { Role } from '@prisma/client';
+
 export class RoomUpdateRoleEvent {
   roomId: number;
+  userId: number;
+  role: Role;
 }

--- a/backend/src/common/events/room-update-role.event.ts
+++ b/backend/src/common/events/room-update-role.event.ts
@@ -1,0 +1,3 @@
+export class RoomUpdateRoleEvent {
+  roomId: number;
+}

--- a/backend/src/room/mute/mute.controller.spec.ts
+++ b/backend/src/room/mute/mute.controller.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { MuteController } from './mute.controller';
@@ -9,7 +10,7 @@ describe('MuteController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MuteController],
-      providers: [MuteService, PrismaService],
+      providers: [MuteService, PrismaService, EventEmitter2],
     }).compile();
 
     controller = module.get<MuteController>(MuteController);

--- a/backend/src/room/mute/mute.service.spec.ts
+++ b/backend/src/room/mute/mute.service.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { MuteService } from './mute.service';
@@ -7,7 +8,7 @@ describe('MuteService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MuteService, PrismaService],
+      providers: [MuteService, PrismaService, EventEmitter2],
     }).compile();
 
     service = module.get<MuteService>(MuteService);

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -294,6 +294,8 @@ export class RoomService {
     });
     const event: RoomUpdateRoleEvent = {
       roomId: roomId,
+      userId: userId,
+      role: dto.role,
     };
     this.eventEmitter.emit('room.update.role', event);
     return res;

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -8,6 +8,7 @@ import { Role, User } from '@prisma/client';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
 import { RoomLeftEvent } from 'src/common/events/room-left.event';
+import { RoomUpdateRoleEvent } from 'src/common/events/room-update-role.event';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { UpdateUserOnRoomDto } from './dto/update-UserOnRoom.dto';
@@ -277,12 +278,12 @@ export class RoomService {
     });
   };
 
-  updateUserOnRoom = (
+  updateUserOnRoom = async (
     roomId: number,
     userId: number,
     dto: UpdateUserOnRoomDto,
   ): Promise<UserOnRoomEntity> => {
-    return this.prisma.userOnRoom.update({
+    const res = await this.prisma.userOnRoom.update({
       where: {
         userId_roomId_unique: {
           roomId: roomId,
@@ -291,6 +292,11 @@ export class RoomService {
       },
       data: dto,
     });
+    const event: RoomUpdateRoleEvent = {
+      roomId: roomId,
+    };
+    this.eventEmitter.emit('room.update.role', event);
+    return res;
   };
 
   async kickUser(roomId: number, userId: number): Promise<UserOnRoomEntity> {

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -963,7 +963,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
   });
 
   describe('Client notification on chat channel actions', () => {
-    describe('user enter notification', () => {
+    describe('Notification that a user has entered', () => {
       let room;
       let ctx7: Promise<void[]>;
       beforeAll(async () => {
@@ -993,14 +993,14 @@ describe('ChatGateway and ChatController (e2e)', () => {
         await app.deleteRoom(room.id, user1.accessToken).expect(204);
       });
 
-      it('user2 enters room', async () => {
+      it('is sent when user2 enters the room', async () => {
         await app.enterRoom(room.id, user2.accessToken).expect(201);
       });
 
-      it('Room members should receive notification when a user enters the room', async () => {
+      it('should be received by room members', async () => {
         await ctx7;
       });
-      it('not member user should not receive notification when a user enters the room', (done) => {
+      it('should not be received by non-members', (done) => {
         const mockEnterEventListener = jest.fn();
         ws3.on('enter-room', mockEnterEventListener);
         setTimeout(() => {
@@ -1010,7 +1010,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
         }, waitTime);
       });
     });
-    describe('update role notification', () => {
+    describe('Notification that a user has updated role', () => {
       let room;
       let ctx8: Promise<void[]>;
       beforeAll(async () => {
@@ -1041,7 +1041,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
         await app.deleteRoom(room.id, user1.accessToken).expect(204);
       });
 
-      it('user1 updates user2 role to admin', async () => {
+      it('is sent when user1 updates user2 role to admin', async () => {
         await app
           .updateUserOnRoom(
             room.id,
@@ -1052,11 +1052,11 @@ describe('ChatGateway and ChatController (e2e)', () => {
           .expect(200);
       });
 
-      it('Room members should receive notification when a user updates role', async () => {
+      it('should be received by room members.', async () => {
         await ctx8;
       });
 
-      it('not member user should not receive notification when a user updates role', (done) => {
+      it('should not be received by non-members', (done) => {
         const mockUpdateRoleEventListener = jest.fn();
         ws3.on('update-role', mockUpdateRoleEventListener);
         setTimeout(() => {
@@ -1066,7 +1066,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
         }, waitTime);
       });
     });
-    describe('user mute notification', () => {
+    describe('Notification that a user has muted', () => {
       let room;
       let ctx9: Promise<void[]>;
       let ctx10: Promise<void[]>;
@@ -1109,15 +1109,15 @@ describe('ChatGateway and ChatController (e2e)', () => {
         await app.deleteRoom(room.id, user1.accessToken).expect(204);
       });
 
-      it('user1 mutes user2', async () => {
+      it('is sent when user1 mutes user2', async () => {
         await app.muteUser(room.id, user2.id, user1.accessToken).expect(200);
       });
 
-      it('Room members should receive notification when a user mutes', async () => {
+      it('should be received by room members', async () => {
         await ctx9;
       });
 
-      it('not member user should not receive notification when a user mutes', (done) => {
+      it('should not be received by non-members', (done) => {
         const mockMuteEventListener = jest.fn();
         ws3.on('mute', mockMuteEventListener);
         setTimeout(() => {
@@ -1126,23 +1126,26 @@ describe('ChatGateway and ChatController (e2e)', () => {
           done();
         }, waitTime);
       });
+      describe('Notification that a user has unmuted', () => {
+        it('is sent when user1 unmutes user2', async () => {
+          await app
+            .unmuteUser(room.id, user2.id, user1.accessToken)
+            .expect(200);
+        });
 
-      it('user1 unmutes user2', async () => {
-        await app.unmuteUser(room.id, user2.id, user1.accessToken).expect(200);
-      });
+        it('should be received by room members', async () => {
+          await ctx10;
+        });
 
-      it('Room members should receive notification when a user unmutes', async () => {
-        await ctx10;
-      });
-
-      it('not member user should not receive notification when a user unmutes', (done) => {
-        const mockUnmuteEventListener = jest.fn();
-        ws3.on('unmute', mockUnmuteEventListener);
-        setTimeout(() => {
-          expect(mockUnmuteEventListener).not.toBeCalled();
-          ws3.off('unmute');
-          done();
-        }, waitTime);
+        it('should not be received by non-members', (done) => {
+          const mockUnmuteEventListener = jest.fn();
+          ws3.on('unmute', mockUnmuteEventListener);
+          setTimeout(() => {
+            expect(mockUnmuteEventListener).not.toBeCalled();
+            ws3.off('unmute');
+            done();
+          }, waitTime);
+        });
       });
     });
   });


### PR DESCRIPTION
- enter roomとupdate roomをした時にroom参加者がイベントを受け取れるか確認するテストを追加しました。
- enter roomとupdate roleした時にgatewayからclientにイベントを発行するように変更しました。

追加したテスト
<img width="544" alt="スクリーンショット 2024-02-03 16 51 20" src="https://github.com/usatie/pong/assets/90199432/1357adf1-dce6-4b95-9fd8-d80a759d4188">
