### PR TITLE
Feat/backend/fix review/0131

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -30,6 +30,23 @@ import { Response } from 'express';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  constants = {
+    loginUrl: ((): string => {
+      const clientId = process.env.OAUTH_42_CLIENT_ID;
+      const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
+      const redirectUri =
+        process.env.NEST_PUBLIC_API_URL + '/auth/login/oauth2/42/callback';
+      return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+    })(),
+    signupUrl: ((): string => {
+      const clientId = process.env.OAUTH_42_CLIENT_ID;
+      const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
+      const redirectUri =
+        process.env.NEST_PUBLIC_API_URL + '/auth/signup/oauth2/42/callback';
+      return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+    })(),
+  };
+
   @Post('login')
   @ApiOkResponse({ type: AuthEntity })
   login(@Body() { email, password }: LoginDto): Promise<AuthEntity> {
@@ -40,9 +57,8 @@ export class AuthController {
   @ApiOkResponse({ type: AuthEntity })
   @Redirect()
   redirectToOauth42() {
-    return this.authService.redirectToOauth42(
-      '/auth/signup/oauth2/42/callback',
-    );
+    // TODO : implement state system for enhanced security
+    return { url: this.constants.signupUrl };
   }
 
   @Get('signup/oauth2/42/callback')
@@ -56,7 +72,8 @@ export class AuthController {
   @ApiOkResponse({ type: AuthEntity })
   @Redirect()
   redirectToOauth42ToLogin() {
-    return this.authService.redirectToOauth42('/auth/login/oauth2/42/callback');
+    // TODO : implement state system for enhanced security
+    return { url: this.constants.loginUrl };
   }
 
   @Get('login/oauth2/42/callback')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -25,27 +25,27 @@ import { AuthEntity } from './entity/auth.entity';
 import { JwtGuardWithout2FA } from './jwt-auth.guard';
 import { Response } from 'express';
 
+const constants = {
+  loginUrl: ((): string => {
+    const clientId = process.env.OAUTH_42_CLIENT_ID;
+    const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
+    const redirectUri =
+      process.env.NEST_PUBLIC_API_URL + '/auth/login/oauth2/42/callback';
+    return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+  })(),
+  signupUrl: ((): string => {
+    const clientId = process.env.OAUTH_42_CLIENT_ID;
+    const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
+    const redirectUri =
+      process.env.NEST_PUBLIC_API_URL + '/auth/signup/oauth2/42/callback';
+    return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+  })(),
+};
+
 @Controller('auth')
 @ApiTags('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
-
-  constants = {
-    loginUrl: ((): string => {
-      const clientId = process.env.OAUTH_42_CLIENT_ID;
-      const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
-      const redirectUri =
-        process.env.NEST_PUBLIC_API_URL + '/auth/login/oauth2/42/callback';
-      return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
-    })(),
-    signupUrl: ((): string => {
-      const clientId = process.env.OAUTH_42_CLIENT_ID;
-      const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
-      const redirectUri =
-        process.env.NEST_PUBLIC_API_URL + '/auth/signup/oauth2/42/callback';
-      return `${codeEndpointUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
-    })(),
-  };
 
   @Post('login')
   @ApiOkResponse({ type: AuthEntity })
@@ -58,7 +58,7 @@ export class AuthController {
   @Redirect()
   redirectToOauth42() {
     // TODO : implement state system for enhanced security
-    return { url: this.constants.signupUrl };
+    return { url: constants.signupUrl };
   }
 
   @Get('signup/oauth2/42/callback')
@@ -73,7 +73,7 @@ export class AuthController {
   @Redirect()
   redirectToOauth42ToLogin() {
     // TODO : implement state system for enhanced security
-    return { url: this.constants.loginUrl };
+    return { url: constants.loginUrl };
   }
 
   @Get('login/oauth2/42/callback')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -84,13 +84,13 @@ export class AuthService {
     });
   }
 
-  getAccessTokenWith42 = async ({
+  async getAccessTokenWith42({
     code,
     redirect_uri,
   }: {
     code: string;
     redirect_uri;
-  }) => {
+  }) {
     const form = new URLSearchParams({
       grant_type: 'authorization_code',
       client_id: process.env.OAUTH_42_CLIENT_ID,
@@ -115,9 +115,9 @@ export class AuthService {
         });
       }
     });
-  };
+  }
 
-  getUserInfoWith42 = async ({ access_token }: { access_token: string }) => {
+  async getUserInfoWith42({ access_token }: { access_token: string }) {
     return fetch('https://api.intra.42.fr/v2/me', {
       headers: {
         Authorization: `Bearer ${access_token}`,
@@ -128,10 +128,10 @@ export class AuthService {
       }
       return res.json();
     });
-  };
+  }
 
-  signupWithOauth42 = (code: string): Promise<User> =>
-    this.getAccessTokenWith42({
+  signupWithOauth42(code: string): Promise<User> {
+    return this.getAccessTokenWith42({
       code,
       redirect_uri: '/auth/signup/oauth2/42/callback',
     }).then(
@@ -152,8 +152,9 @@ export class AuthService {
       // // TODO : random password? without password?
       // // TODO : save access_token in db
     );
+  }
 
-  loginWithOauth42 = async (code: string): Promise<AuthEntity> => {
+  async loginWithOauth42(code: string): Promise<AuthEntity> {
     return this.getAccessTokenWith42({
       code,
       redirect_uri: '/auth/login/oauth2/42/callback',
@@ -183,7 +184,7 @@ export class AuthService {
           });
       });
     });
-  };
+  }
 
   async pipeQrCodeStream(stream: Response, otpAuthUrl: string) {
     return toFileStream(stream, otpAuthUrl);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -84,16 +84,6 @@ export class AuthService {
     });
   }
 
-  redirectToOauth42 = (callbackUri: string) => {
-    const client_id = process.env.OAUTH_42_CLIENT_ID;
-    const redirect_uri = process.env.NEST_PUBLIC_API_URL + callbackUri;
-    // TODO : implement state system for enhanced security
-    const codeEndpointUrl = 'https://api.intra.42.fr/oauth/authorize';
-    return {
-      url: `${codeEndpointUrl}?client_id=${client_id}&redirect_uri=${redirect_uri}&response_type=code`,
-    };
-  };
-
   getAccessTokenWith42 = async ({
     code,
     redirect_uri,

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1426,39 +1426,4 @@ describe('ChatGateway and ChatController (e2e)', () => {
       });
     });
   });
-  describe('online status', () => {
-    let onlineUser;
-    let onlineUserSocket;
-    let offlineUser;
-
-    beforeAll(async () => {
-      onlineUser = user1;
-      onlineUserSocket = io('ws://localhost:3000/chat', {
-        extraHeaders: { cookie: 'token=' + onlineUser.accessToken },
-      });
-      await connect(onlineUserSocket);
-      offlineUser = user2;
-    });
-    afterAll(() => {
-      onlineUserSocket.close();
-    });
-
-    it('connected user should be online', async () => {
-      const res = await app
-        .isOnline(onlineUser.id, onlineUser.accessToken)
-        .expect(200);
-      const body = res.body;
-      expect(body.isOnline).toEqual(true);
-    });
-    it('disconnected user should be offline', async () => {
-      const res = await app
-        .isOnline(offlineUser.id, offlineUser.accessToken)
-        .expect(200);
-      const body = res.body;
-      expect(body.isOnline).toEqual(false);
-    });
-    it('check online status with invalid access token should be unauthorized', async () => {
-      await app.isOnline(onlineUser.id, '').expect(401);
-    });
-  });
 });

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1432,13 +1432,6 @@ describe('ChatGateway and ChatController (e2e)', () => {
     let offlineUser;
 
     beforeAll(async () => {
-      ws1.close();
-      ws2.close();
-      ws3.close();
-      ws4.close();
-      ws5.close();
-      ws6.close();
-      ws7.close();
       onlineUser = user1;
       onlineUserSocket = io('ws://localhost:3000/chat', {
         extraHeaders: { cookie: 'token=' + onlineUser.accessToken },

--- a/backend/test/online-status.e2e-spec.ts
+++ b/backend/test/online-status.e2e-spec.ts
@@ -68,14 +68,14 @@ describe('ChatGateway and ChatController (e2e)', () => {
       onlineUserSocket.close();
     });
 
-    it('connected user should be online', async () => {
+    it('online user should be true (online)', async () => {
       const res = await app
         .isOnline(onlineUser.id, onlineUser.accessToken)
         .expect(200);
       const body = res.body;
       expect(body.isOnline).toEqual(true);
     });
-    it('disconnected user should be offline', async () => {
+    it('offline user should be false (offline)', async () => {
       const res = await app
         .isOnline(offlineUser.id, offlineUser.accessToken)
         .expect(200);

--- a/backend/test/online-status.e2e-spec.ts
+++ b/backend/test/online-status.e2e-spec.ts
@@ -1,0 +1,89 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Socket, io } from 'socket.io-client';
+import { AppModule } from 'src/app.module';
+import { TestApp, UserEntityWithAccessToken } from './utils/app';
+
+async function createNestApp(): Promise<INestApplication> {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  return app;
+}
+
+describe('ChatGateway and ChatController (e2e)', () => {
+  let app: TestApp;
+  let user1;
+  let user2;
+
+  beforeAll(async () => {
+    //app = await initializeApp();
+    const _app = await createNestApp();
+    await _app.listen(3000);
+    app = new TestApp(_app);
+    const dto1 = {
+      name: 'test-user1',
+      email: 'test1@test.com',
+      password: 'test-password',
+    };
+    const dto2 = {
+      name: 'test-user2',
+      email: 'test2@test.com',
+      password: 'test-password',
+    };
+    user1 = await app.createAndLoginUser(dto1);
+    user2 = await app.createAndLoginUser(dto2);
+  });
+
+  afterAll(async () => {
+    await app.deleteUser(user1.id, user1.accessToken).expect(204);
+    await app.deleteUser(user2.id, user2.accessToken).expect(204);
+    await app.close();
+  });
+
+  const connect = (ws: Socket) => {
+    return new Promise<void>((resolve) => {
+      ws.on('connect', () => {
+        resolve();
+      });
+    });
+  };
+
+  describe('online status', () => {
+    let onlineUser;
+    let onlineUserSocket;
+    let offlineUser;
+
+    beforeAll(async () => {
+      onlineUser = user1;
+      onlineUserSocket = io('ws://localhost:3000/chat', {
+        extraHeaders: { cookie: 'token=' + onlineUser.accessToken },
+      });
+      await connect(onlineUserSocket);
+      offlineUser = user2;
+    });
+    afterAll(() => {
+      onlineUserSocket.close();
+    });
+
+    it('connected user should be online', async () => {
+      const res = await app
+        .isOnline(onlineUser.id, onlineUser.accessToken)
+        .expect(200);
+      const body = res.body;
+      expect(body.isOnline).toEqual(true);
+    });
+    it('disconnected user should be offline', async () => {
+      const res = await app
+        .isOnline(offlineUser.id, offlineUser.accessToken)
+        .expect(200);
+      const body = res.body;
+      expect(body.isOnline).toEqual(false);
+    });
+    it('check online status with invalid access token should be unauthorized', async () => {
+      await app.isOnline(onlineUser.id, '').expect(401);
+    });
+  });
+});

--- a/backend/test/online-status.e2e-spec.ts
+++ b/backend/test/online-status.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Socket, io } from 'socket.io-client';
 import { AppModule } from 'src/app.module';
-import { TestApp, UserEntityWithAccessToken } from './utils/app';
+import { TestApp } from './utils/app';
 
 async function createNestApp(): Promise<INestApplication> {
   const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
[うさみさんのレビュー](https://github.com/usatie/pong/pull/230)
に対応しました

テストについて
- マジックナンバー
- 変数名をクリアに
- 関数名をクリアに
というところらへん

online status を API でとるかws でとるかは質問したいです
自分のメリデメの認識

API
- status の変化をリアルタイムに受け取れない ( reload しないと変更されない )
- 実装コストが低い

ws
- status の変化をリアルタイムに受け取れる
- 実装コストが少し高い? ( 複数の user の online status 部分を useStatus を使って管理する方法がパッと書けなかった)