### PR TITLE
[frontend] manage users online status

### DIFF
--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -886,10 +886,3 @@ export async function createUserWithOauth(
     redirect("/login");
   }
 }
-
-export const isOnline = async (userId: number) =>
-  fetch(`${process.env.API_URL}/chat/${userId}/online`, {
-    headers: {
-      Authorization: "Bearer " + getAccessToken(),
-    },
-  }).then((res) => (res.ok ? res.json() : Promise.reject(res)));

--- a/frontend/app/ui/user/user-list.tsx
+++ b/frontend/app/ui/user/user-list.tsx
@@ -4,7 +4,6 @@ import type { PublicUserEntity } from "@/app/lib/dtos";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Avatar, AvatarSize } from "./avatar";
 import { useEffect, useState } from "react";
-import { isOnline } from "@/app/lib/actions";
 
 export default function UserList({
   users,

--- a/frontend/app/ui/user/user-list.tsx
+++ b/frontend/app/ui/user/user-list.tsx
@@ -12,26 +12,6 @@ export default function UserList({
   users: PublicUserEntity[];
   avatarSize: AvatarSize;
 }) {
-  const [onlineStatus, setOnlineStatus] = useState<{ [key: string]: boolean }>(
-    {},
-  );
-
-  const fetchOnlineStatus = async () => {
-    try {
-      users.forEach(async (u) => {
-        const body = await isOnline(u.id);
-        const online = body.isOnline;
-        setOnlineStatus((prev) => ({ ...prev, [u.name]: online }));
-      });
-    } catch (error) {
-      console.error("Error fetching online status:", error);
-    }
-  };
-
-  useEffect(() => {
-    fetchOnlineStatus();
-  }, []);
-
   return (
     <TooltipProvider delayDuration={0}>
       <div className="flex flex-wrap gap-2">
@@ -42,7 +22,7 @@ export default function UserList({
             size={avatarSize}
             href={`/user/${u.id}`}
             alt={u.name}
-            online={onlineStatus[u.name]}
+            online={true}
             key={u.id}
           />
         ))}


### PR DESCRIPTION
web socket で online status を管理する 変数を providerに用意しました。
以前使っていた、API で取得する群は一度消したので、online status の表示は静的になっています。

TODO:
- online status の情報を必要なページに共有する(use context?)