### PR TITLE
[backend] handling owner leaves room and delete room notification

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -166,7 +166,7 @@ export class ChatGateway {
     this.chatService.handleChangeOnlineStatus(event);
     this.server.emit('online-status', event);
   }
-  
+
   @OnEvent('room.delete', { async: true })
   async handleDelete(event: RoomDeletedEvent) {
     if (event.accessLevel === 'PUBLIC' || event.accessLevel === 'PROTECTED') {

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -158,9 +158,13 @@ export class ChatGateway {
 
   @OnEvent('room.delete', { async: true })
   async handleDelete(event: RoomDeletedEvent) {
-    this.server
-      .in(event.roomId.toString())
-      .emit('delete-room', { roomId: event.roomId });
+    if (event.accessLevel === 'PUBLIC' || event.accessLevel === 'PROTECTED') {
+      this.server.emit('delete-room', { roomId: event.roomId });
+    } else {
+      this.server
+        .in(event.roomId.toString())
+        .emit('delete-room', { roomId: event.roomId });
+    }
     this.chatService.deleteSocketRoom(event);
   }
 

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -8,6 +8,7 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { RoomDeletedEvent } from 'src/common/events/room-deleted.event';
 import { RoomEnteredEvent } from 'src/common/events/room-entered.event';
 import { RoomMuteEvent } from 'src/common/events/room-mute.event';
 import { RoomUnmuteEvent } from 'src/common/events/room-unmute.event';
@@ -155,16 +156,24 @@ export class ChatGateway {
     }
   }
 
+  @OnEvent('room.delete', { async: true })
+  async handleDelete(event: RoomDeletedEvent) {
+    this.server
+      .in(event.roomId.toString())
+      .emit('delete-room', { roomId: event.roomId });
+    this.chatService.deleteSocketRoom(event);
+  }
+
   @OnEvent('room.enter', { async: true })
   async handleEnter(event: RoomEnteredEvent) {
-    await this.chatService.addUserToRoom(event.roomId, event.userId);
+    this.chatService.addUserToRoom(event.roomId, event.userId);
     this.server.in(event.roomId.toString()).emit('enter-room', event);
   }
 
   @OnEvent('room.leave', { async: true })
   async handleLeave(event: RoomLeftEvent) {
     this.server.in(event.roomId.toString()).emit('leave', event);
-    await this.chatService.removeUserFromRoom(event);
+    this.chatService.removeUserFromRoom(event.roomId, event.userId);
   }
 
   @OnEvent('room.update.role', { async: true })

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -6,7 +6,7 @@ import { Socket } from 'socket.io';
 import { AuthService } from 'src/auth/auth.service';
 import { BlockEvent } from 'src/common/events/block.event';
 import { RoomCreatedEvent } from 'src/common/events/room-created.event';
-import { RoomLeftEvent } from 'src/common/events/room-left.event';
+import { RoomDeletedEvent } from 'src/common/events/room-deleted.event';
 import { UnblockEvent } from 'src/common/events/unblock.event';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UserService } from 'src/user/user.service';
@@ -77,6 +77,13 @@ export class ChatService {
     }
   }
 
+  removeUserFromRoom(roomId: number, userId: number) {
+    const client = this.clients.get(userId);
+    if (client) {
+      client.leave(roomId.toString());
+    }
+  }
+
   getUsersBlockedBy(userId: number) {
     return this.prisma.user
       .findUniqueOrThrow({
@@ -89,13 +96,6 @@ export class ChatService {
   @OnEvent('room.created', { async: true })
   async handleRoomCreatedEvent(event: RoomCreatedEvent) {
     await this.addUserToRoom(event.roomId, event.userId);
-  }
-
-  async removeUserFromRoom(event: RoomLeftEvent) {
-    const client = this.clients.get(event.userId);
-    if (client) {
-      client.leave(event.roomId.toString());
-    }
   }
 
   @OnEvent('block', { async: true })
@@ -124,8 +124,11 @@ export class ChatService {
     });
   }
 
-  deleteRoom(roomId: number) {
-    roomId;
+  deleteSocketRoom(event: RoomDeletedEvent) {
+    event.userIds.forEach((userId) =>
+      this.removeUserFromRoom(event.roomId, userId),
+    );
+
     // TODO: delete room
     // this.server.socketsLeave(roomId.toString());
   }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -140,9 +140,6 @@ export class ChatService {
     event.userIds.forEach((userId) =>
       this.removeUserFromRoom(event.roomId, userId),
     );
-
-    // TODO: delete room
-    // this.server.socketsLeave(roomId.toString());
   }
 
   sendToRoom(roomId: number, event: string, data: any) {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -96,6 +96,11 @@ export class ChatService {
   @OnEvent('room.created', { async: true })
   async handleRoomCreatedEvent(event: RoomCreatedEvent) {
     await this.addUserToRoom(event.roomId, event.userId);
+    if (event.userIds) {
+      event.userIds.forEach((userId) =>
+        this.addUserToRoom(event.roomId, userId),
+      );
+    }
   }
 
   @OnEvent('block', { async: true })

--- a/backend/src/common/events/room-created.event.ts
+++ b/backend/src/common/events/room-created.event.ts
@@ -1,4 +1,5 @@
 export class RoomCreatedEvent {
   roomId: number;
   userId: number;
+  userIds?: number[];
 }

--- a/backend/src/common/events/room-deleted.event.ts
+++ b/backend/src/common/events/room-deleted.event.ts
@@ -1,4 +1,5 @@
 export class RoomDeletedEvent {
   roomId: number;
   userIds: number[];
+  accessLevel: 'PUBLIC' | 'PRIVATE' | 'PROTECTED' | 'DIRECT';
 }

--- a/backend/src/common/events/room-deleted.event.ts
+++ b/backend/src/common/events/room-deleted.event.ts
@@ -1,0 +1,4 @@
+export class RoomDeletedEvent {
+  roomId: number;
+  userIds: number[];
+}

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -327,7 +327,6 @@ export class RoomService {
         },
       },
     });
-    // TODO: If owner leaves the room, the room should be deleted or a new owner should be assigned
     if (deletedUserOnRoom.role === Role.OWNER) {
       await this.removeRoom(roomId);
     }

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -326,6 +326,9 @@ export class RoomService {
       },
     });
     // TODO: If owner leaves the room, the room should be deleted or a new owner should be assigned
+    if (deletedUserOnRoom.role === Role.OWNER) {
+      await this.removeRoom(roomId);
+    }
     const event: RoomLeftEvent = {
       roomId: roomId,
       userId: userId,

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -66,6 +66,7 @@ export class RoomService {
     const event: RoomCreatedEvent = {
       roomId: room.id,
       userId: user.id,
+      userIds,
     };
     this.eventEmitter.emit('room.created', event);
     return room;
@@ -207,6 +208,7 @@ export class RoomService {
     const event: RoomDeletedEvent = {
       roomId: roomId,
       userIds: memberIds,
+      accessLevel: deletedRoom.accessLevel,
     };
     this.eventEmitter.emit('room.delete', event);
     return deletedRoom;

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1149,6 +1149,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
         });
       });
     });
+
     describe('Notification that deleted a room', () => {
       const setupRoom = async (createRoomDto: CreateRoomDto) => {
         const dto = { ...createRoomDto, userIds: [user2.id] };
@@ -1182,15 +1183,14 @@ describe('ChatGateway and ChatController (e2e)', () => {
         afterAll(async () => {
           await app.deleteRoom(_publicRoom.id, user1.accessToken);
         });
-
         it('is sent when user1 deletes the public room', async () => {
           await app.deleteRoom(_publicRoom.id, user1.accessToken).expect(204);
         });
-
         it('should be received by all users', async () => {
           await ctx11;
         });
       });
+
       describe('Notification that deleted a protected room', () => {
         let _protectedRoom;
         let ctx12: Promise<void[]>;
@@ -1215,17 +1215,16 @@ describe('ChatGateway and ChatController (e2e)', () => {
         afterAll(async () => {
           await app.deleteRoom(_protectedRoom.id, user1.accessToken);
         });
-
         it('is sent when user1 deletes the protected room', async () => {
           await app
             .deleteRoom(_protectedRoom.id, user1.accessToken)
             .expect(204);
         });
-
         it('should be received by all users', async () => {
           await ctx12;
         });
       });
+
       describe('Notification that deleted a private room', () => {
         let _privateRoom;
         let ctx13: Promise<void[]>;
@@ -1250,14 +1249,12 @@ describe('ChatGateway and ChatController (e2e)', () => {
         afterAll(async () => {
           await app.deleteRoom(_privateRoom.id, user1.accessToken);
         });
-
         it('is sent when user1 deletes the private room', async () => {
           await app.deleteRoom(_privateRoom.id, user1.accessToken).expect(204);
         });
         it('should be received by room members', async () => {
           await ctx13;
         });
-
         it('should not be received by non-members', (done) => {
           const mockDeleteRoomEventListener = jest.fn();
           ws3.on('delete-room', mockDeleteRoomEventListener);
@@ -1269,6 +1266,7 @@ describe('ChatGateway and ChatController (e2e)', () => {
         });
       });
     });
+
     describe('Notification that owner has left the room (delete-room)', () => {
       let room;
       let ctx14: Promise<void[]>;
@@ -1299,23 +1297,11 @@ describe('ChatGateway and ChatController (e2e)', () => {
       afterAll(async () => {
         await app.deleteRoom(room.id, user1.accessToken);
       });
-
       it('is sent when owner(user1) leaves the public room', async () => {
         await app.leaveRoom(room.id, user1.accessToken).expect(204);
       });
-
       it('should be received by all users', async () => {
         await ctx14;
-      });
-
-      it('should not be received by non-members', (done) => {
-        const mockKickEventListener = jest.fn();
-        ws3.on('delete-room', mockKickEventListener);
-        setTimeout(() => {
-          expect(mockKickEventListener).not.toBeCalled();
-          ws3.off('delete-room');
-          done();
-        }, waitTime);
       });
     });
   });

--- a/backend/test/chat-gateway.e2e-spec.ts
+++ b/backend/test/chat-gateway.e2e-spec.ts
@@ -1158,7 +1158,6 @@ describe('ChatGateway and ChatController (e2e)', () => {
         return room;
       };
 
-      //
       describe('Notification that deleted a public room', () => {
         let _publicRoom;
         let ctx11: Promise<void[]>;
@@ -1180,6 +1179,10 @@ describe('ChatGateway and ChatController (e2e)', () => {
           );
           ctx11 = Promise.all(promises);
         });
+        afterAll(async () => {
+          await app.deleteRoom(_publicRoom.id, user1.accessToken);
+        });
+
         it('is sent when user1 deletes the public room', async () => {
           await app.deleteRoom(_publicRoom.id, user1.accessToken).expect(204);
         });
@@ -1209,6 +1212,10 @@ describe('ChatGateway and ChatController (e2e)', () => {
           );
           ctx12 = Promise.all(promises);
         });
+        afterAll(async () => {
+          await app.deleteRoom(_protectedRoom.id, user1.accessToken);
+        });
+
         it('is sent when user1 deletes the protected room', async () => {
           await app
             .deleteRoom(_protectedRoom.id, user1.accessToken)
@@ -1240,6 +1247,10 @@ describe('ChatGateway and ChatController (e2e)', () => {
           );
           ctx13 = Promise.all(promises);
         });
+        afterAll(async () => {
+          await app.deleteRoom(_privateRoom.id, user1.accessToken);
+        });
+
         it('is sent when user1 deletes the private room', async () => {
           await app.deleteRoom(_privateRoom.id, user1.accessToken).expect(204);
         });
@@ -1285,8 +1296,11 @@ describe('ChatGateway and ChatController (e2e)', () => {
         );
         ctx14 = Promise.all(promises);
       });
+      afterAll(async () => {
+        await app.deleteRoom(room.id, user1.accessToken);
+      });
 
-      it('is sent when OWENER(user1) leaves the public room', async () => {
+      it('is sent when owner(user1) leaves the public room', async () => {
         await app.leaveRoom(room.id, user1.accessToken).expect(204);
       });
 

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -976,6 +976,15 @@ describe('RoomController (e2e)', () => {
       test('should leave protected room (204 No Content)', async () => {
         await app.leaveRoom(_protectedRoom.id, owner.accessToken).expect(204);
       });
+      test('should not get public room after owner leaves (404 Not Found)', async () => {
+        return app.getRoom(_publicRoom.id, owner.accessToken).expect(404);
+      });
+      test('should not get private room after owner leaves (404 Not Found)', async () => {
+        return app.getRoom(_privateRoom.id, owner.accessToken).expect(404);
+      });
+      test('should not get protected room after owner leaves (404 Not Found)', async () => {
+        return app.getRoom(_protectedRoom.id, owner.accessToken).expect(404);
+      });
     });
     describe('admin', () => {
       beforeAll(setupRooms);

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -966,7 +966,6 @@ describe('RoomController (e2e)', () => {
     describe('owner', () => {
       beforeAll(setupRooms);
       afterAll(teardownRooms);
-      // TODO: What if owner leaves the room?
       test('should leave public room (204 No Content)', async () => {
         await app.leaveRoom(_publicRoom.id, owner.accessToken).expect(204);
       });

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -979,6 +979,8 @@ describe('RoomController (e2e)', () => {
         return app.getRoom(_publicRoom.id, owner.accessToken).expect(404);
       });
       test('should not get private room after owner leaves (404 Not Found)', async () => {
+        await app.getRoom(_privateRoom.id, member.accessToken).expect(404);
+        await app.getRoom(_privateRoom.id, admin.accessToken).expect(404);
         return app.getRoom(_privateRoom.id, owner.accessToken).expect(404);
       });
       test('should not get protected room after owner leaves (404 Not Found)', async () => {


### PR DESCRIPTION
- roomを削除した時の通知とownerが退出した時の通知、roomの削除を確認するテストを追加しました。
- roomを削除した時に通知を出すように変更しました。
- ownerがroomを退出した時にroomを削除するように変更しました。
- create roomでuserIdsが存在した時にuserIdsのユーザー達をsocketのroomにjoinさせるように修正しました。

追加したテスト
<img width="712" alt="スクリーンショット 2024-02-07 15 50 34" src="https://github.com/usatie/pong/assets/90199432/d480cad6-09e6-4f6f-b157-5ceec69c2350">
<img width="550" alt="スクリーンショット 2024-02-08 16 58 47" src="https://github.com/usatie/pong/assets/90199432/509cd54f-ef91-40bd-978a-944b4176c346">
