### PR TITLE
[frontend] Refactoring of socket event handling for room action

### DIFF
--- a/frontend/app/explore-rooms/explore-rooms.tsx
+++ b/frontend/app/explore-rooms/explore-rooms.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import RoomCard from "./room-card";
+import { useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { DeleteRoomEvent, RoomEntity } from "@/app/lib/dtos";
+import { chatSocket as socket } from "@/socket";
+
+export function ExploreRooms({ rooms }: { rooms: RoomEntity[] }) {
+  const router = useRouter();
+  const handleDeleteRoomEvent = useCallback(
+    (data: DeleteRoomEvent) => {
+      router.refresh();
+    },
+    [router],
+  );
+  useEffect(() => {
+    socket.on("delete-room", handleDeleteRoomEvent);
+    return () => {
+      socket.off("delete-room", handleDeleteRoomEvent);
+    };
+  }, [handleDeleteRoomEvent]);
+  return (
+    <div className="flex flex-col gap-8">
+      <h1 className="text-4xl font-bold">Explore Rooms</h1>
+      <div className="flex flex-wrap gap-4">
+        {rooms.map((room) => (
+          <RoomCard room={room} key={room.id} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/explore-rooms/page.tsx
+++ b/frontend/app/explore-rooms/page.tsx
@@ -1,16 +1,11 @@
 import { getRooms } from "@/app/lib/actions";
-import RoomCard from "./room-card";
+import { ExploreRooms } from "./explore-rooms";
 
 export default async function ExploreRoomsPage() {
   const rooms = await getRooms({ joined: false });
   return (
-    <div className="flex flex-col gap-8">
-      <h1 className="text-4xl font-bold">Explore Rooms</h1>
-      <div className="flex flex-wrap gap-4">
-        {rooms.map((room) => (
-          <RoomCard room={room} key={room.id} />
-        ))}
-      </div>
-    </div>
+    <>
+      <ExploreRooms rooms={rooms} />
+    </>
   );
 }

--- a/frontend/app/lib/client-socket-provider.tsx
+++ b/frontend/app/lib/client-socket-provider.tsx
@@ -7,10 +7,7 @@ import { useCallback, useEffect } from "react";
 import { useAuthContext } from "./client-auth";
 import {
   DenyEvent,
-  DeleteRoomEvent,
-  EnterRoomEvent,
   InviteEvent,
-  LeaveRoomEvent,
   MatchEvent,
   MessageEvent,
   PublicUserEntity,
@@ -31,56 +28,6 @@ export default function SocketProvider() {
       description: "The chat room has been deleted",
     });
   };
-
-  const handleDeleteRoomEvent = useCallback(
-    (data: DeleteRoomEvent) => {
-      if (pathName === "/room/" + data.roomId.toString()) {
-        showDeleteRoomNotificationToast();
-        router.push("/room");
-        router.refresh();
-      } else if (
-        pathName.startsWith("/room/") ||
-        pathName === "/explore-rooms"
-      ) {
-        router.refresh();
-      }
-    },
-    [pathName, router],
-  );
-
-  const handleEnterRoomEvent = useCallback(
-    (data: EnterRoomEvent) => {
-      if (pathName === "/room/" + data.roomId.toString()) {
-        router.refresh();
-      } else if (
-        (pathName.startsWith("/room/") || pathName === "/room") &&
-        currentUser?.id === data.userId
-      ) {
-        router.refresh();
-      }
-    },
-    [currentUser, pathName, router],
-  );
-
-  const handleLeaveRoomEvent = useCallback(
-    (data: LeaveRoomEvent) => {
-      if (
-        pathName === "/room/" + data.roomId.toString() &&
-        data.userId === currentUser?.id
-      ) {
-        router.push("/room");
-        router.refresh();
-      } else if (pathName === "/room/" + data.roomId.toString()) {
-        router.refresh();
-      } else if (
-        (pathName.startsWith("/room/") || pathName === "/room") &&
-        currentUser?.id === data.userId
-      ) {
-        router.refresh();
-      }
-    },
-    [currentUser, pathName, router],
-  );
 
   const MatchPong = (data: MatchEvent) => {
     router.push(`/pong/${data.roomId}?mode=player`);
@@ -168,13 +115,10 @@ export default function SocketProvider() {
     const handler = (event: string, data: any) => {
       if (event === "message") {
         showMessageToast(data);
-      } else if (event === "delete-room") {
-        handleDeleteRoomEvent(data);
-      } else if (event === "enter-room") {
-        handleEnterRoomEvent(data);
-      } else if (event === "leave") {
-        handleLeaveRoomEvent(data);
       } else if (
+        event === "delete-room" ||
+        event === "enter-room" ||
+        event === "leave" ||
         event === "mute" ||
         event === "unmute" ||
         event === "update-role"
@@ -202,12 +146,6 @@ export default function SocketProvider() {
       chatSocket.offAny(handler);
       chatSocket.disconnect();
     };
-  }, [
-    currentUser,
-    handleDeleteRoomEvent,
-    handleEnterRoomEvent,
-    handleLeaveRoomEvent,
-    toast,
-  ]);
+  }, [currentUser, toast]);
   return <></>;
 }


### PR DESCRIPTION
- roomのアクション(enter、leaveなど)関連のsocketイベントハンドリングをclient-socket-provider.tsxから削除し、実際にハンドリンが必要な場所に移動させました。