### PR TITLE
[backend] Add password to protected room in seed

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -55,6 +55,7 @@ async function seedRooms(users) {
       data: {
         name: 'Room 2',
         accessLevel: 'PROTECTED',
+        password: bcrypt.hashSync('password', roundsOfHashing),
         users: {
           create: [
             { userId: user1.id, role: 'MEMBER' },


### PR DESCRIPTION
- seedのprotected roomにpasswordを追加して、後からexplore-roomsのjoinボタンを押して参加できるようにしました。
passwordは"password"です。