### PR TITLE
[frontend/backend] Fix dm room name

### DIFF
--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -73,8 +73,10 @@ export class RoomService {
 
   findAllRoom(userId: number, joined?: boolean): Promise<Room[]> {
     let users;
+    let includeUsers = false;
     if (joined) {
       users = { some: { userId: userId } };
+      includeUsers = true;
     } else if (joined === false) {
       users = { none: { userId: userId } };
     }
@@ -96,6 +98,21 @@ export class RoomService {
         // Should not include room for banned users
         BannedUsers: { none: { userId: userId } },
       },
+      include: includeUsers
+        ? {
+            users: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    avatarURL: true,
+                  },
+                },
+              },
+            },
+          }
+        : undefined,
     });
   }
 

--- a/backend/test/room.e2e-spec.ts
+++ b/backend/test/room.e2e-spec.ts
@@ -6,7 +6,11 @@ import supertest from 'supertest';
 import { constants } from './constants';
 import { TestApp, UserEntityWithAccessToken } from './utils/app';
 import { initializeApp } from './utils/initialize';
-import { expectPublicUser, expectRoom } from './utils/matcher';
+import {
+  expectPublicUser,
+  expectRoom,
+  expectRoomWithUsers,
+} from './utils/matcher';
 
 describe('RoomController (e2e)', () => {
   let app: TestApp;
@@ -713,6 +717,16 @@ describe('RoomController (e2e)', () => {
         _rooms.forEach((room) =>
           expect(room.accessLevel).not.toEqual('PRIVATE'),
         );
+      });
+    });
+    describe('whit joined query', () => {
+      it('should return only joined rooms with joined users info', async () => {
+        const res = await app
+          .getRoomsWithQueryOfJoined(owner.accessToken)
+          .expect(200);
+        const rooms = res.body;
+        expect(rooms).toBeInstanceOf(Array);
+        rooms.forEach(expectRoomWithUsers);
       });
     });
   });

--- a/backend/test/utils/app.ts
+++ b/backend/test/utils/app.ts
@@ -62,6 +62,11 @@ export class TestApp {
       .get(`/room`)
       .set('Authorization', `Bearer ${accessToken}`);
 
+  getRoomsWithQueryOfJoined = (accessToken: string) =>
+    request(this.app.getHttpServer())
+      .get(`/room?joined=true`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
   /* Room API (Private) */
   createRoom = (createRoomDto: CreateRoomDto, accessToken: string) =>
     request(this.app.getHttpServer())

--- a/frontend/app/lib/dtos.ts
+++ b/frontend/app/lib/dtos.ts
@@ -86,4 +86,9 @@ export type ApprovedMatchRequestEvent = {
 
 export type DenyEvent = {};
 
-export type RoomEntity = { id: number; name: string; accessLevel: AccessLevel };
+export type RoomEntity = {
+  id: number;
+  name: string;
+  accessLevel: AccessLevel;
+  users?: UserOnRoomEntity[];
+};

--- a/frontend/app/room/rooms-sidebar.tsx
+++ b/frontend/app/room/rooms-sidebar.tsx
@@ -10,9 +10,11 @@ import CreateRoomDialog from "./create-room-dialog";
 
 function RoomButton({
   room,
+  meId,
   selected,
 }: {
   room: RoomEntity;
+  meId: number | undefined;
   selected: boolean;
 }) {
   const router = useRouter();
@@ -20,6 +22,13 @@ function RoomButton({
     router.push(`${room.id}`);
     router.refresh();
   };
+  let roomName = room.name;
+  if (room.accessLevel === "DIRECT") {
+    const otherUser = room.users?.find((user) => user.userId !== meId);
+    if (otherUser) {
+      roomName = otherUser.user.name;
+    }
+  }
   return (
     <button
       key={room.id}
@@ -28,7 +37,7 @@ function RoomButton({
         selected ? "bg-secondary" : ""
       }`}
     >
-      {room.name}
+      {roomName}
     </button>
   );
 }
@@ -77,6 +86,7 @@ export default function RoomsSidebar({ rooms }: { rooms: RoomEntity[] }) {
         {rooms.map((room) => (
           <RoomButton
             room={room}
+            meId={currentUser?.id}
             selected={room.id === selectedRoomId}
             key={room.id}
           />


### PR DESCRIPTION
[backend]
- getRoomsのqueryがjoined=trueだった時のテストを追加しました。
- getRoomsのqueryがjoined=trueだった時にroomのメンバー情報も含めて返すように変更しました。

[frontend]
- RoomSidebarで表示していた参加済みroom一覧の表示room名をDMときはDM相手の名前を表示するように修正しました。

<img width="1440" alt="スクリーンショット 2024-02-27 15 16 46" src="https://github.com/usatie/pong/assets/90199432/49f7b9d5-e65a-4ac8-8666-c6aa573f7ac1">
