### PR TITLE
[frontend] Handle unhandled errors

### DIFF
--- a/frontend/app/(guest-only)/login/error.tsx
+++ b/frontend/app/(guest-only)/login/error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="flex h-full flex-col items-center justify-center">
+      <h2 className="text-center">Something went wrong!</h2>
+      <button
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-red-400"
+        onClick={() => reset()}
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -73,6 +73,7 @@ export async function authenticate(
 function getAccessToken() {
   const accessToken = cookies()?.get("token")?.value;
   if (!accessToken) {
+    console.error("No access token found");
     throw new Error("No access token found");
   }
   return accessToken;
@@ -169,7 +170,7 @@ export async function getRooms(query: any = {}): Promise<RoomEntity[]> {
   });
   if (!res.ok) {
     console.error("getRooms error: ", await res.json());
-    throw new Error("getRooms error");
+    return [];
   }
   const rooms = await res.json();
   return rooms;
@@ -403,7 +404,11 @@ export async function kickUserOnRoom(roomId: number, userId: number) {
 export async function signInAsTestUser() {
   const email = "test@example.com";
   const password = "password-test";
-  await signIn({ email, password });
+  try {
+    await signIn({ email, password });
+  } catch (error) {
+    console.error("signInAsTestUser error: ", error);
+  }
   redirect("/");
 }
 
@@ -800,7 +805,8 @@ export async function muteUser(
   durationSec?: number,
 ) {
   if (durationSec && durationSec < 0) {
-    throw new Error("Duration must be positive");
+    console.error("Duration must be positive");
+    return "Error";
   }
   const res = await fetch(
     `${process.env.API_URL}/room/${roomId}/mutes/${userId}`,
@@ -832,7 +838,7 @@ export async function getMutedUsers(roomId: number) {
   });
   if (!res.ok) {
     console.error("getMutedUsers error: ", await res.json());
-    return null;
+    return [];
   } else {
     const mutedUsers = res.json();
     return mutedUsers;
@@ -890,7 +896,7 @@ export async function getBannedUsers(roomId: number) {
   });
   if (!res.ok) {
     console.error("getBannedUsers error: ", await res.json());
-    return null;
+    return [];
   } else {
     const bannedUsers = res.json();
     return bannedUsers;

--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getMessages, getRoom, getUsers } from "@/app/lib/actions";
 import { Separator } from "@/components/ui/separator";
+import { notFound } from "next/navigation";
 import MessageArea from "./message-area";
 import RoomDetail from "./room-detail";
 
@@ -9,7 +10,12 @@ export default async function Page({
   params: { id: string };
 }) {
   const roomId = Number(id);
-  const room = await getRoom(roomId);
+  let room;
+  try {
+    room = await getRoom(roomId);
+  } catch (e) {
+    notFound();
+  }
   const messages = await getMessages(roomId);
   const allUsers = await getUsers();
   return (

--- a/frontend/app/ui/user/accept-friend-request-button.tsx
+++ b/frontend/app/ui/user/accept-friend-request-button.tsx
@@ -7,16 +7,20 @@ import { toast } from "@/components/ui/use-toast";
 const showErrorToast = () => {
   toast({
     title: "Error",
-    description: "An error occurred while accepting the friend request",
+    description: (
+      <>
+        Failed to confirm friend request.
+        <br />
+        Please reload the page and try again.
+      </>
+    ),
   });
 };
 
 export default function AcceptFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => acceptFriendRequest(id), undefined);
-  return (
-    <>
-      <Button onClick={action}>Confirm</Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
-  );
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
+  return <Button onClick={action}>Confirm</Button>;
 }

--- a/frontend/app/ui/user/accept-friend-request-button.tsx
+++ b/frontend/app/ui/user/accept-friend-request-button.tsx
@@ -2,8 +2,21 @@
 import { acceptFriendRequest } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "An error occurred while accepting the friend request",
+  });
+};
 
 export default function AcceptFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => acceptFriendRequest(id), undefined);
-  return <Button onClick={action}>Confirm</Button>;
+  return (
+    <>
+      <Button onClick={action}>Confirm</Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
+  );
 }

--- a/frontend/app/ui/user/add-friend-button.tsx
+++ b/frontend/app/ui/user/add-friend-button.tsx
@@ -13,10 +13,8 @@ const showErrorToast = () => {
 
 export default function AddFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => addFriend(id), undefined);
-  return (
-    <>
-      <Button onClick={action}>Add Friend</Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
-  );
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
+  return <Button onClick={action}>Add Friend</Button>;
 }

--- a/frontend/app/ui/user/add-friend-button.tsx
+++ b/frontend/app/ui/user/add-friend-button.tsx
@@ -2,8 +2,21 @@
 import { addFriend } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "Failed to send friend request",
+  });
+};
 
 export default function AddFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => addFriend(id), undefined);
-  return <Button onClick={action}>Add Friend</Button>;
+  return (
+    <>
+      <Button onClick={action}>Add Friend</Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
+  );
 }

--- a/frontend/app/ui/user/block-button.tsx
+++ b/frontend/app/ui/user/block-button.tsx
@@ -2,8 +2,21 @@
 import { blockUser } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "failed to block user",
+  });
+};
 
 export default function BlockButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => blockUser(id), undefined);
-  return <Button onClick={action}>Block</Button>;
+  return (
+    <>
+      <Button onClick={action}>Block</Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
+  );
 }

--- a/frontend/app/ui/user/block-button.tsx
+++ b/frontend/app/ui/user/block-button.tsx
@@ -13,10 +13,8 @@ const showErrorToast = () => {
 
 export default function BlockButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => blockUser(id), undefined);
-  return (
-    <>
-      <Button onClick={action}>Block</Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
-  );
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
+  return <Button onClick={action}>Block</Button>;
 }

--- a/frontend/app/ui/user/cancel-friend-request-button.tsx
+++ b/frontend/app/ui/user/cancel-friend-request-button.tsx
@@ -2,12 +2,23 @@
 import { cancelFriendRequest } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "An error occurred while canceling the friend request",
+  });
+};
 
 export default function CancelFriendRequestButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => cancelFriendRequest(id), undefined);
   return (
-    <Button onClick={action} variant={"outline"}>
-      Cancel Friend Request
-    </Button>
+    <>
+      <Button onClick={action} variant={"outline"}>
+        Cancel Friend Request
+      </Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
   );
 }

--- a/frontend/app/ui/user/cancel-friend-request-button.tsx
+++ b/frontend/app/ui/user/cancel-friend-request-button.tsx
@@ -7,18 +7,24 @@ import { toast } from "@/components/ui/use-toast";
 const showErrorToast = () => {
   toast({
     title: "Error",
-    description: "An error occurred while canceling the friend request",
+    description: (
+      <>
+        Failed to cancel friend request.
+        <br />
+        Please reload the page and try again.
+      </>
+    ),
   });
 };
 
 export default function CancelFriendRequestButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => cancelFriendRequest(id), undefined);
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
   return (
-    <>
-      <Button onClick={action} variant={"outline"}>
-        Cancel Friend Request
-      </Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
+    <Button onClick={action} variant={"outline"}>
+      Cancel Friend Request
+    </Button>
   );
 }

--- a/frontend/app/ui/user/direct-message-button.tsx
+++ b/frontend/app/ui/user/direct-message-button.tsx
@@ -4,7 +4,14 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
 
-const showErrorToast = () => {
+const showCreateDirectRoomErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "Failed to create direct message room",
+  });
+};
+
+const showGetDirectRoomErrorToast = () => {
   toast({
     title: "Error",
     description: "Something went wrong. Please try again later.",
@@ -17,12 +24,15 @@ export default function DirectMessageButton({ id }: { id: number }) {
     try {
       const room = await getDirectRoom(id);
       if (room.statusCode === 404) {
-        await createDirectRoom(id);
+        const result = await createDirectRoom(id);
+        if (result.error) {
+          showCreateDirectRoomErrorToast();
+        }
       } else {
         router.push(`/room/${room.id}`);
       }
     } catch (e) {
-      showErrorToast();
+      showGetDirectRoomErrorToast();
     }
   };
   return <Button onClick={createOrRedirectDirectRoom}>Message</Button>;

--- a/frontend/app/ui/user/direct-message-button.tsx
+++ b/frontend/app/ui/user/direct-message-button.tsx
@@ -1,18 +1,29 @@
 "use client";
 import { createDirectRoom, getDirectRoom } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
 import { useRouter } from "next/navigation";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "Something went wrong. Please try again later.",
+  });
+};
 
 export default function DirectMessageButton({ id }: { id: number }) {
   const router = useRouter();
-  const onClick = async () => {
-    const room = await getDirectRoom(id);
-    console.log(room);
-    if (room.statusCode === 404) {
-      await createDirectRoom(id);
-    } else {
-      router.push(`/room/${room.id}`);
+  const createOrRedirectDirectRoom = async () => {
+    try {
+      const room = await getDirectRoom(id);
+      if (room.statusCode === 404) {
+        await createDirectRoom(id);
+      } else {
+        router.push(`/room/${room.id}`);
+      }
+    } catch (e) {
+      showErrorToast();
     }
   };
-  return <Button onClick={onClick}>Message</Button>;
+  return <Button onClick={createOrRedirectDirectRoom}>Message</Button>;
 }

--- a/frontend/app/ui/user/reject-friend-request-button.tsx
+++ b/frontend/app/ui/user/reject-friend-request-button.tsx
@@ -2,12 +2,23 @@
 import { rejectFriendRequest } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "An error occurred while rejecting the friend request",
+  });
+};
 
 export default function RejectFriendRequestButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => rejectFriendRequest(id), undefined);
   return (
-    <Button onClick={action} variant={"outline"}>
-      Delete Request
-    </Button>
+    <>
+      <Button onClick={action} variant={"outline"}>
+        Delete Request
+      </Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
   );
 }

--- a/frontend/app/ui/user/reject-friend-request-button.tsx
+++ b/frontend/app/ui/user/reject-friend-request-button.tsx
@@ -7,18 +7,24 @@ import { toast } from "@/components/ui/use-toast";
 const showErrorToast = () => {
   toast({
     title: "Error",
-    description: "An error occurred while rejecting the friend request",
+    description: (
+      <>
+        Failed to delete friend request.
+        <br />
+        Please reload the page and try again.
+      </>
+    ),
   });
 };
 
 export default function RejectFriendRequestButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => rejectFriendRequest(id), undefined);
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
   return (
-    <>
-      <Button onClick={action} variant={"outline"}>
-        Delete Request
-      </Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
+    <Button onClick={action} variant={"outline"}>
+      Delete Request
+    </Button>
   );
 }

--- a/frontend/app/ui/user/remove-friend-button.tsx
+++ b/frontend/app/ui/user/remove-friend-button.tsx
@@ -13,12 +13,12 @@ const showErrorToast = () => {
 
 export default function RemoveFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => unfriend(id), undefined);
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
   return (
-    <>
-      <Button onClick={action} variant={"outline"}>
-        Remove Friend
-      </Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
+    <Button onClick={action} variant={"outline"}>
+      Remove Friend
+    </Button>
   );
 }

--- a/frontend/app/ui/user/remove-friend-button.tsx
+++ b/frontend/app/ui/user/remove-friend-button.tsx
@@ -2,12 +2,23 @@
 import { unfriend } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "Failed to remove friend",
+  });
+};
 
 export default function RemoveFriendButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => unfriend(id), undefined);
   return (
-    <Button onClick={action} variant={"outline"}>
-      Remove Friend
-    </Button>
+    <>
+      <Button onClick={action} variant={"outline"}>
+        Remove Friend
+      </Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
   );
 }

--- a/frontend/app/ui/user/unblock-button.tsx
+++ b/frontend/app/ui/user/unblock-button.tsx
@@ -13,12 +13,12 @@ const showErrorToast = () => {
 
 export default function UnblockButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => unblockUser(id), undefined);
+  if (code && code !== "Success") {
+    showErrorToast();
+  }
   return (
-    <>
-      <Button onClick={action} variant={"outline"}>
-        Unblock
-      </Button>
-      {code && code !== "Success" && showErrorToast()}
-    </>
+    <Button onClick={action} variant={"outline"}>
+      Unblock
+    </Button>
   );
 }

--- a/frontend/app/ui/user/unblock-button.tsx
+++ b/frontend/app/ui/user/unblock-button.tsx
@@ -2,12 +2,23 @@
 import { unblockUser } from "@/app/lib/actions";
 import { Button } from "@/components/ui/button";
 import { useFormState } from "react-dom";
+import { toast } from "@/components/ui/use-toast";
+
+const showErrorToast = () => {
+  toast({
+    title: "Error",
+    description: "failed to unblock user",
+  });
+};
 
 export default function UnblockButton({ id }: { id: number }) {
   const [code, action] = useFormState(() => unblockUser(id), undefined);
   return (
-    <Button onClick={action} variant={"outline"}>
-      Unblock
-    </Button>
+    <>
+      <Button onClick={action} variant={"outline"}>
+        Unblock
+      </Button>
+      {code && code !== "Success" && showErrorToast()}
+    </>
   );
 }

--- a/frontend/app/user/[id]/not-found.tsx
+++ b/frontend/app/user/[id]/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex h-full flex-col items-center justify-center gap-2">
+      <h2 className="text-xl font-semibold">404 Not Found</h2>
+      <p>Could not find the requested user.</p>
+      <Link
+        href="/user"
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-white transition-colors hover:bg-red-400"
+      >
+        Go Back
+      </Link>
+    </main>
+  );
+}

--- a/frontend/app/user/[id]/page.tsx
+++ b/frontend/app/user/[id]/page.tsx
@@ -18,6 +18,7 @@ import RejectFriendButton from "@/app/ui/user/reject-friend-request-button";
 import RemoveFriendButton from "@/app/ui/user/remove-friend-button";
 import Stats from "@/app/ui/user/stats";
 import UnBlockButton from "@/app/ui/user/unblock-button";
+import { notFound } from "next/navigation";
 
 export default async function FindUser({
   params: { id },
@@ -26,6 +27,9 @@ export default async function FindUser({
 }) {
   const userId = parseInt(id, 10);
   const user = await getUser(userId);
+  if (!user) {
+    notFound();
+  }
   const requests = await getFriendRequests();
   const currentUserId = await getCurrentUserId();
   const myFriends = await getFriends(currentUserId);


### PR DESCRIPTION
- errorを投げたがuncaught errorになっていた箇所を修正しました。
- getUserでnullが返ってきた時にNotFoundページを表示するように修正しました。(404以外もnotFoundに行ってしまうので微妙)
- getRoomでerrorが投げられた時にerrorページが表示されていたのをNotFoundページを表示するように修正しました。(userと同じく404以外もnotFoundに行ってしまうので微妙かも)
- 各ユーザーページでユーザーがアクション(add frined、blockなど)を行った時のエラー通知をtoastでするように修正しました。