### PR TITLE
[backend] Validated to prevent saving empty messages

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -65,6 +65,10 @@ export class ChatGateway {
     if (MutedUsers.some((user) => user.id === data.userId)) {
       return;
     }
+    if (data.content.length < 1) {
+      this.logger.error('no content in message');
+      return;
+    }
 
     // Save message to the database
     await this.chatService.createMessage(data);


### PR DESCRIPTION
- backend側で中身が空のメッセージを保存できるようになってしまっていたため、保存できないように修正しました。