### PR TITLE
[frontend] Fix to connect socket only when currentUser can be obtained

### DIFF
--- a/frontend/app/lib/client-socket-provider.tsx
+++ b/frontend/app/lib/client-socket-provider.tsx
@@ -143,8 +143,10 @@ export default function SocketProvider() {
         showNotificationToast(data);
       }
     };
-    chatSocket.onAny(handler);
-    chatSocket.connect();
+    if (currentUser) {
+      chatSocket.onAny(handler);
+      chatSocket.connect();
+    }
     return () => {
       chatSocket.offAny(handler);
       chatSocket.disconnect();


### PR DESCRIPTION
-  client-socket-providerでuseAuthContextからcurrentUserを取得できる時だけsocket接続とイベント登録をするように修正しました。