### PR TITLE
[frontend] Moved redirect function out of try-catch block

### DIFF
--- a/frontend/app/lib/actions.ts
+++ b/frontend/app/lib/actions.ts
@@ -269,7 +269,7 @@ export async function createDirectRoom(userId: number) {
   }
   if (!res.ok) {
     console.error("createDirectRoom error: ", data);
-    return { error: data.message };
+    return "Error";
   } else {
     redirect(`/room/${data.id}`);
   }

--- a/frontend/app/ui/user/direct-message-button.tsx
+++ b/frontend/app/ui/user/direct-message-button.tsx
@@ -21,18 +21,19 @@ const showGetDirectRoomErrorToast = () => {
 export default function DirectMessageButton({ id }: { id: number }) {
   const router = useRouter();
   const createOrRedirectDirectRoom = async () => {
+    let room;
     try {
-      const room = await getDirectRoom(id);
-      if (room.statusCode === 404) {
-        const result = await createDirectRoom(id);
-        if (result.error) {
-          showCreateDirectRoomErrorToast();
-        }
-      } else {
-        router.push(`/room/${room.id}`);
-      }
+      room = await getDirectRoom(id);
     } catch (e) {
-      showGetDirectRoomErrorToast();
+      return showGetDirectRoomErrorToast();
+    }
+    if (room.statusCode === 404) {
+      const result = await createDirectRoom(id);
+      if (result === "Error") {
+        showCreateDirectRoomErrorToast();
+      }
+    } else {
+      router.push(`/room/${room.id}`);
     }
   };
   return <Button onClick={createOrRedirectDirectRoom}>Message</Button>;


### PR DESCRIPTION
- nextjsのredirect関数をtry-catch文の中に入れてしまっていたので修正しました。
https://nextjs.org/docs/app/building-your-application/routing/redirecting#redirect-function