### PR TITLE
[backend] Extended expiration of access token

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -23,7 +23,7 @@ export const jwtConstants = {
     JwtModule.register({
       privateKey: jwtConstants.privateKey,
       signOptions: {
-        expiresIn: '30m',
+        expiresIn: '3h',
         algorithm: 'RS256',
       },
       verifyOptions: {


### PR DESCRIPTION
- トークンの有効期限を30分から3時間に変更しました。