### PR TITLE
[frontend] Fixed to call notFound function instead of throwing Error object

### DIFF
--- a/frontend/app/room/[id]/page.tsx
+++ b/frontend/app/room/[id]/page.tsx
@@ -3,6 +3,7 @@ import { Separator } from "@/components/ui/separator";
 import { notFound } from "next/navigation";
 import MessageArea from "./message-area";
 import RoomDetail from "./room-detail";
+import { getCurrentUserId } from "@/app/lib/session";
 
 export default async function Page({
   params: { id },
@@ -18,12 +19,22 @@ export default async function Page({
   }
   const messages = await getMessages(roomId);
   const allUsers = await getUsers();
+  const currentUserId = await getCurrentUserId();
+  const me = room.users.find((u) => u.userId === currentUserId);
+  if (!me) {
+    notFound();
+  }
   return (
     <>
       <div className="overflow-auto flex-grow flex gap-4 pb-4">
         <MessageArea roomId={roomId} messages={messages} />
         <Separator orientation="vertical" />
-        <RoomDetail room={room} users={room.users} allUsers={allUsers} />
+        <RoomDetail
+          room={room}
+          users={room.users}
+          allUsers={allUsers}
+          me={me}
+        />
       </div>
     </>
   );

--- a/frontend/app/room/[id]/room-detail.tsx
+++ b/frontend/app/room/[id]/room-detail.tsx
@@ -18,14 +18,10 @@ interface Props {
   room: RoomEntity;
   users: UserOnRoomEntity[];
   allUsers: PublicUserEntity[];
+  me: UserOnRoomEntity;
 }
 
-export default async function RoomDetail({ room, users, allUsers }: Props) {
-  const currentUserId = await getCurrentUserId();
-  const me = users.find((u) => u.userId === currentUserId);
-  if (!me) {
-    throw new Error("User not found");
-  }
+export default async function RoomDetail({ room, users, allUsers, me }: Props) {
   const bannedUsers = (await getBannedUsers(room.id)) ?? [];
   const blockingUsers = (await getBlockingUsers()) ?? [];
   const mutedUsers = (await getMutedUsers(room.id)) ?? [];


### PR DESCRIPTION
- currentUserが、存在するが参加していないroomにアクセスしたときError objectをthrowするようにしていた場所をnextjsのnotFound関数を呼ぶように修正しました。
(なぜかroom-detailでnotFound関数を呼ぶと開発者ツールのconsoleに404ではなく500が出るので親コンポーネントのpageコンポーネントで処理しています(console上は500だがnot-found.tsxに遷移するので謎))